### PR TITLE
fix black picture issue

### DIFF
--- a/public/js/triage/triage.js
+++ b/public/js/triage/triage.js
@@ -223,9 +223,12 @@ var patientPhotoFeature = {
     },
     prepareForPOST: function () {
         //0.5 is the quality downgrade.
-        var dataURL = document.getElementById('patientPhotoCanvas').toDataURL("image/jpeg", 0.5);
-        $('#photoInputCropped').val(dataURL);
-        $('#photoInput').remove();//remove file upload from DOM so it's not submitted in POST
+        var canvas = document.getElementById('patientPhotoCanvas');
+        if (!isCanvasBlank(canvas)){
+            var dataURL = canvas.toDataURL("image/jpeg", 0.5);
+            $('#photoInputCropped').val(dataURL);
+            $('#photoInput').remove();//remove file upload from DOM so it's not submitted in POST
+        }
     }
 
 };
@@ -520,6 +523,14 @@ $(document).ready(function () {
 
 
 });
+
+function isCanvasBlank(canvas){
+    var blank = document.createElement('canvas');
+    blank.width = canvas.width;
+    blank.height = canvas.height;
+
+    return canvas.toDataURL() == blank.toDataURL();
+}
 
 
 $(function () {


### PR DESCRIPTION
If a user didn't set a picture for a patient, the system would create a black picture for that patient instead of not creating one.