### PR TITLE
remove faulty sex null check that was wrongly added in recent refactoring

### DIFF
--- a/app/femr/business/services/core/IPatientService.java
+++ b/app/femr/business/services/core/IPatientService.java
@@ -34,10 +34,11 @@ public interface IPatientService {
     ServiceResponse<Map<String,String>> retrieveAgeClassifications();
 
     /**
-     * Updates a patients sex if that patient does not previously have one assigned.
+     * Updates a patients sex if that patient does not previously have one assigned. If sex is null then it just gets and
+     * returns the patient.
      *
      * @param id the id of the patient, not null
-     * @param sex the sex of the patient, not null
+     * @param sex the sex of the patient, may be null
      * @return a service response that contains a PatientItem representing the patient that was updated
      * and/or errors if they exist.
      */

--- a/app/femr/business/services/system/PatientService.java
+++ b/app/femr/business/services/system/PatientService.java
@@ -89,12 +89,6 @@ public class PatientService implements IPatientService {
 
         ServiceResponse<PatientItem> response = new ServiceResponse<>();
 
-        if (StringUtils.isNullOrWhiteSpace(sex)){
-
-            response.addError("sex", "you must provide a sex to update with");
-            return response;
-        }
-
         ExpressionList<Patient> query = QueryProvider.getPatientQuery()
                 .where()
                 .eq("id", id);

--- a/app/femr/ui/controllers/TriageController.java
+++ b/app/femr/ui/controllers/TriageController.java
@@ -71,8 +71,8 @@ public class TriageController extends Controller {
         }
 
         //get age classifications
-        ServiceResponse<Map<String,String>> patientAgeClassificationsResponse = patientService.retrieveAgeClassifications();
-        if (patientAgeClassificationsResponse.hasErrors()){
+        ServiceResponse<Map<String, String>> patientAgeClassificationsResponse = patientService.retrieveAgeClassifications();
+        if (patientAgeClassificationsResponse.hasErrors()) {
             throw new RuntimeException();
         }
 
@@ -113,8 +113,8 @@ public class TriageController extends Controller {
         }
 
         //get age classifications
-        ServiceResponse<Map<String,String>> patientAgeClassificationsResponse = patientService.retrieveAgeClassifications();
-        if (patientAgeClassificationsResponse.hasErrors()){
+        ServiceResponse<Map<String, String>> patientAgeClassificationsResponse = patientService.retrieveAgeClassifications();
+        if (patientAgeClassificationsResponse.hasErrors()) {
             throw new RuntimeException();
         }
 
@@ -132,6 +132,7 @@ public class TriageController extends Controller {
    * if id is > 0 then it is only a new encounter
     */
     public Result indexPost(int id) {
+
         IndexViewModelPost viewModel = IndexViewModelForm.bindFromRequest().get();
         CurrentUser currentUser = sessionService.retrieveCurrentUserSession();
 


### PR DESCRIPTION
was getting errors when creating an encounter for a patient that already had their sex identified. This fixes that problem.