### PR TITLE
add evolution to fix issue with null chief complaint sort orders

### DIFF
--- a/conf/evolutions/default/74.sql
+++ b/conf/evolutions/default/74.sql
@@ -1,0 +1,10 @@
+# --- !Ups
+
+SET @code=0;
+UPDATE chief_complaints
+SET sort_order = (SELECT @code:=@code+1 AS code);
+
+# --- !Downs
+
+UPDATE chief_complaints
+SET sort_order = NULL;


### PR DESCRIPTION
Assigns an increasing sort order number to all chief complaints to avoid dealing with NULL. All chief complaints in the future have at least a 0 sort order.