### PR TITLE
Mark Patients as Deleted

### DIFF
--- a/app/femr/business/helpers/QueryHelper.java
+++ b/app/femr/business/helpers/QueryHelper.java
@@ -102,6 +102,7 @@ public class QueryHelper {
                 .fetch("patientEncounters.missionTrip.missionCity")
                 .fetch("patientEncounters.missionTrip.missionCity.missionCountry")
                 .where()
+                .isNull("isDeleted")
                 .eq("patientEncounters.missionTrip.missionCity.missionCountry.name", country);
 
         return patientExpressionList.findList();
@@ -112,6 +113,11 @@ public class QueryHelper {
      */
     public static List<? extends IPatient> findPatients(IRepository<IPatient> patientRepository){
 
-        return patientRepository.findAll(Patient.class);
+        ExpressionList<Patient> patientExpressionList = QueryProvider.getPatientQuery()
+                .select("*")
+                .where()
+                .isNull("isDeleted");
+
+        return patientExpressionList.findList();
     }
 }

--- a/app/femr/business/services/core/IPatientService.java
+++ b/app/femr/business/services/core/IPatientService.java
@@ -52,4 +52,11 @@ public interface IPatientService {
      * and/or errors if they exist.
      */
     ServiceResponse<PatientItem> createPatient(PatientItem patient);
+
+    /**
+     * Soft deletes a patient
+     * @return a service response that contains a PatientItem representing that the patient was deleted
+     * and/or errors if they exist.
+     */
+    ServiceResponse<PatientItem> deletePatient(int patientId);
 }

--- a/app/femr/business/services/system/PatientService.java
+++ b/app/femr/business/services/system/PatientService.java
@@ -33,6 +33,7 @@ import femr.data.models.core.*;
 import femr.data.models.mysql.Patient;
 import femr.data.models.mysql.PatientAgeClassification;
 import femr.util.stringhelpers.StringUtils;
+import org.joda.time.DateTime;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -132,7 +133,8 @@ public class PatientService implements IPatientService {
                     null,
                     null,
                     photoPath,
-                    photoId);
+                    photoId,
+                    null);
             response.setResponseObject(patientItem);
 
         } catch (Exception ex) {
@@ -176,8 +178,61 @@ public class PatientService implements IPatientService {
                             null,
                             null,
                             photoPath,
-                            photoId)
+                            photoId,
+                            null)
             );
+        } catch (Exception ex) {
+            response.addError("exception", ex.getMessage());
+        }
+
+        return response;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ServiceResponse<PatientItem> deletePatient(int id){
+
+        ServiceResponse<PatientItem> response = new ServiceResponse<>();
+
+        ExpressionList<Patient> query = QueryProvider.getPatientQuery()
+                .where()
+                .eq("id", id);
+
+        try {
+
+            IPatient savedPatient = patientRepository.findOne(query);
+
+            if( savedPatient == null ){
+
+                response.addError("exception", "Patient Not Found");
+                return response;
+            }
+
+            String photoPath = null;
+            Integer photoId = null;
+            if (savedPatient.getPhoto() != null) {
+                photoPath = savedPatient.getPhoto().getFilePath();
+                photoId = savedPatient.getPhoto().getId();
+            }
+            PatientItem patientItem = itemModelMapper.createPatientItem(savedPatient.getId(),
+                    savedPatient.getFirstName(),
+                    savedPatient.getLastName(),
+                    savedPatient.getCity(),
+                    savedPatient.getAddress(),
+                    savedPatient.getUserId(),
+                    savedPatient.getAge(),
+                    savedPatient.getSex(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    photoPath,
+                    photoId,
+                    DateTime.now());
+            response.setResponseObject(patientItem);
+
         } catch (Exception ex) {
             response.addError("exception", ex.getMessage());
         }

--- a/app/femr/business/services/system/PatientService.java
+++ b/app/femr/business/services/system/PatientService.java
@@ -133,8 +133,7 @@ public class PatientService implements IPatientService {
                     null,
                     null,
                     photoPath,
-                    photoId,
-                    null);
+                    photoId);
             response.setResponseObject(patientItem);
 
         } catch (Exception ex) {
@@ -178,8 +177,7 @@ public class PatientService implements IPatientService {
                             null,
                             null,
                             photoPath,
-                            photoId,
-                            null)
+                            photoId)
             );
         } catch (Exception ex) {
             response.addError("exception", ex.getMessage());
@@ -203,35 +201,8 @@ public class PatientService implements IPatientService {
         try {
 
             IPatient savedPatient = patientRepository.findOne(query);
-
-            if( savedPatient == null ){
-
-                response.addError("exception", "Patient Not Found");
-                return response;
-            }
-
-            String photoPath = null;
-            Integer photoId = null;
-            if (savedPatient.getPhoto() != null) {
-                photoPath = savedPatient.getPhoto().getFilePath();
-                photoId = savedPatient.getPhoto().getId();
-            }
-            PatientItem patientItem = itemModelMapper.createPatientItem(savedPatient.getId(),
-                    savedPatient.getFirstName(),
-                    savedPatient.getLastName(),
-                    savedPatient.getCity(),
-                    savedPatient.getAddress(),
-                    savedPatient.getUserId(),
-                    savedPatient.getAge(),
-                    savedPatient.getSex(),
-                    null,
-                    null,
-                    null,
-                    null,
-                    photoPath,
-                    photoId,
-                    DateTime.now());
-            response.setResponseObject(patientItem);
+            savedPatient.setIsDeleted(DateTime.now());
+            patientRepository.update(savedPatient);
 
         } catch (Exception ex) {
             response.addError("exception", ex.getMessage());

--- a/app/femr/business/services/system/ResearchService.java
+++ b/app/femr/business/services/system/ResearchService.java
@@ -399,7 +399,8 @@ public class ResearchService implements IResearchService {
 
         // Build Query based on Filters
         Query<ResearchEncounter> researchEncounterQuery = QueryProvider.getResearchEncounterQuery();
-        researchEncounterQuery.fetch("patient");
+                researchEncounterQuery.fetch("patient");
+
 
         if( datasetName.equals("prescribedMeds") || datasetName.equals("dispensedMeds") ){
 
@@ -455,7 +456,7 @@ public class ResearchService implements IResearchService {
 //                e.ge("patient.age", sqlFormat.format(maxBirthDate.toDate()));
 //            }
 //        }
-
+        researchEncounterExpressionList.isNull("patient.isDeleted");
         // add age specific parameters
         if( datasetName.equals("age") ) {
 

--- a/app/femr/business/services/system/SearchService.java
+++ b/app/femr/business/services/system/SearchService.java
@@ -80,6 +80,8 @@ public class SearchService implements ISearchService {
             return response;
         }
 
+
+
         //get patient encounters so we can use the newest one
         Query<PatientEncounter> peQuery = QueryProvider.getPatientEncounterQuery()
                 .where()
@@ -415,6 +417,7 @@ public class SearchService implements ISearchService {
             query = QueryProvider.getPatientQuery()
                     .where()
                     .eq("id", id)
+                    .isNull("isDeleted")
                     .order()
                     .desc("id");
 
@@ -425,6 +428,7 @@ public class SearchService implements ISearchService {
                     .where()
                     .eq("first_name", firstName)
                     .eq("last_name", lastName)
+                    .isNull("isDeleted")
                     .order()
                     .desc("id");
 
@@ -435,6 +439,7 @@ public class SearchService implements ISearchService {
                     .or(
                             Expr.eq("first_name", firstOrLastName),
                             Expr.eq("last_name", firstOrLastName))
+                    .isNull("isDeleted")
                     .order()
                     .desc("id");
 

--- a/app/femr/common/IItemModelMapper.java
+++ b/app/femr/common/IItemModelMapper.java
@@ -21,6 +21,7 @@ package femr.common;
 import femr.common.models.*;
 import femr.data.models.core.*;
 import femr.data.models.mysql.MedicationInventory;
+import org.joda.time.DateTime;
 
 import java.util.Date;
 import java.util.List;
@@ -88,6 +89,7 @@ public interface IItemModelMapper {
      * @param weight             how much the patient weighs, may be null
      * @param pathToPatientPhoto filepath to the patient photo, may be null
      * @param photoId            id of the patients photo, may be null
+     * @param isDeleted          timestamp when a patient is deleted, may be null
      * @return a new PatientItem or null if processing fails, may be null
      */
     PatientItem createPatientItem(int id,
@@ -103,7 +105,8 @@ public interface IItemModelMapper {
                                   Integer heightInches,
                                   Float weight,
                                   String pathToPatientPhoto,
-                                  Integer photoId);
+                                  Integer photoId,
+                                  DateTime isDeleted);
 
     /**
      * Generate and provide an instance of PatientEncounterItem

--- a/app/femr/common/IItemModelMapper.java
+++ b/app/femr/common/IItemModelMapper.java
@@ -89,7 +89,6 @@ public interface IItemModelMapper {
      * @param weight             how much the patient weighs, may be null
      * @param pathToPatientPhoto filepath to the patient photo, may be null
      * @param photoId            id of the patients photo, may be null
-     * @param isDeleted          timestamp when a patient is deleted, may be null
      * @return a new PatientItem or null if processing fails, may be null
      */
     PatientItem createPatientItem(int id,
@@ -105,8 +104,7 @@ public interface IItemModelMapper {
                                   Integer heightInches,
                                   Float weight,
                                   String pathToPatientPhoto,
-                                  Integer photoId,
-                                  DateTime isDeleted);
+                                  Integer photoId);
 
     /**
      * Generate and provide an instance of PatientEncounterItem

--- a/app/femr/common/ItemModelMapper.java
+++ b/app/femr/common/ItemModelMapper.java
@@ -23,6 +23,8 @@ import femr.common.models.*;
 import femr.data.models.core.*;
 import femr.util.calculations.dateUtils;
 import femr.util.stringhelpers.StringUtils;
+import org.joda.time.DateTime;
+
 import java.util.Date;
 import java.util.List;
 
@@ -148,7 +150,8 @@ public class ItemModelMapper implements IItemModelMapper {
                                                 Integer heightInches,
                                                 Float weight,
                                                 String pathToPatientPhoto,
-                                                Integer photoId) {
+                                                Integer photoId,
+                                                DateTime isDeleted) {
 
         if (StringUtils.isNullOrWhiteSpace(firstName) ||
                 StringUtils.isNullOrWhiteSpace(lastName) ||
@@ -196,6 +199,9 @@ public class ItemModelMapper implements IItemModelMapper {
 
         if (weight != null)
             patientItem.setWeight(weight);
+
+        if(isDeleted != null)
+            patientItem.setIsDeleted(isDeleted);
 
         return patientItem;
     }

--- a/app/femr/common/ItemModelMapper.java
+++ b/app/femr/common/ItemModelMapper.java
@@ -150,8 +150,7 @@ public class ItemModelMapper implements IItemModelMapper {
                                                 Integer heightInches,
                                                 Float weight,
                                                 String pathToPatientPhoto,
-                                                Integer photoId,
-                                                DateTime isDeleted) {
+                                                Integer photoId){
 
         if (StringUtils.isNullOrWhiteSpace(firstName) ||
                 StringUtils.isNullOrWhiteSpace(lastName) ||
@@ -199,9 +198,6 @@ public class ItemModelMapper implements IItemModelMapper {
 
         if (weight != null)
             patientItem.setWeight(weight);
-
-        if(isDeleted != null)
-            patientItem.setIsDeleted(isDeleted);
 
         return patientItem;
     }

--- a/app/femr/common/models/PatientItem.java
+++ b/app/femr/common/models/PatientItem.java
@@ -18,6 +18,8 @@
 */
 package femr.common.models;
 
+import org.joda.time.DateTime;
+
 import java.util.Date;
 
 public class PatientItem {
@@ -37,7 +39,7 @@ public class PatientItem {
     private Integer heightFeet;
     private Integer heightInches;
     private Float weight;
-
+    private DateTime isDeleted;
 
 
     public PatientItem(){
@@ -172,5 +174,11 @@ public class PatientItem {
 
     public void setFriendlyDateOfBirth(String friendlyDateOfBirth) {
         this.friendlyDateOfBirth = friendlyDateOfBirth;
+    }
+
+    public DateTime getIsDeleted(){return isDeleted;}
+
+    public void setIsDeleted(DateTime isDeleted){
+        this.isDeleted = isDeleted;
     }
 }

--- a/app/femr/common/models/PatientItem.java
+++ b/app/femr/common/models/PatientItem.java
@@ -39,7 +39,6 @@ public class PatientItem {
     private Integer heightFeet;
     private Integer heightInches;
     private Float weight;
-    private DateTime isDeleted;
 
 
     public PatientItem(){
@@ -174,11 +173,5 @@ public class PatientItem {
 
     public void setFriendlyDateOfBirth(String friendlyDateOfBirth) {
         this.friendlyDateOfBirth = friendlyDateOfBirth;
-    }
-
-    public DateTime getIsDeleted(){return isDeleted;}
-
-    public void setIsDeleted(DateTime isDeleted){
-        this.isDeleted = isDeleted;
     }
 }

--- a/app/femr/data/models/core/IPatient.java
+++ b/app/femr/data/models/core/IPatient.java
@@ -19,6 +19,8 @@
 package femr.data.models.core;
 
 import femr.data.models.mysql.PatientEncounter;
+import org.joda.time.DateTime;
+
 import java.util.Date;
 import java.util.List;
 
@@ -63,4 +65,8 @@ public interface IPatient {
     List<PatientEncounter> getPatientEncounters();
 
     void setPatientEncounters(List<PatientEncounter> patientEncounters);
+
+    DateTime getIsDeleted();
+
+    void setIsDeleted(DateTime isDeleted);
 }

--- a/app/femr/data/models/mysql/Patient.java
+++ b/app/femr/data/models/mysql/Patient.java
@@ -20,6 +20,7 @@ package femr.data.models.mysql;
 
 import femr.data.models.core.IPatient;
 import femr.data.models.core.IPhoto;
+import org.joda.time.DateTime;
 
 import javax.persistence.*;
 import java.util.Date;
@@ -50,6 +51,8 @@ public class Patient implements IPatient {
     private Photo photo;
     @OneToMany(mappedBy = "patient", fetch = FetchType.LAZY)
     private List<PatientEncounter> patientEncounters;
+    @Column(name = "isDeleted", nullable = true)
+    private DateTime isDeleted;
 
     @Override
     public int getId() {
@@ -150,4 +153,15 @@ public class Patient implements IPatient {
     public void setPatientEncounters(List<PatientEncounter> patientEncounters) {
         this.patientEncounters = patientEncounters;
     }
+
+    @Override
+    public DateTime getIsDeleted() {
+        return isDeleted;
+    }
+
+    @Override
+    public void setIsDeleted(DateTime isDeleted) {
+        this.isDeleted = isDeleted;
+    }
+
 }

--- a/app/femr/data/models/mysql/research/ResearchEncounter.java
+++ b/app/femr/data/models/mysql/research/ResearchEncounter.java
@@ -49,7 +49,6 @@ public class ResearchEncounter implements IResearchEncounter {
             mappedBy = "patientEncounter")
     private List<ChiefComplaint> chiefComplaints;
 
-
     @OneToMany(fetch = FetchType.LAZY,
                mappedBy = "patientEncounter")
     @MapKey(name = "vitalId")

--- a/app/femr/ui/controllers/HistoryController.java
+++ b/app/femr/ui/controllers/HistoryController.java
@@ -278,20 +278,7 @@ public class HistoryController extends Controller {
 
         return ok("true");
     }
-    public Result deletePatientPost(int patientId){
-        CurrentUser currentUser = sessionService.retrieveCurrentUserSession();
 
-        //Getting UserItem
-        ServiceResponse<PatientItem> patientItemResponse= patientService.deletePatient(patientId);
-        if(patientItemResponse.hasErrors())
-            throw new RuntimeException();
-
-        PatientItem patient = patientItemResponse.getResponseObject();
-        patient.setIsDeleted(DateTime.now());
-
-
-        return redirect(routes.TriageController.indexGet());
-    }
     /**
      * Gets the partial view that shows the history of tab field items. Called from AJAX.
      */

--- a/app/femr/ui/controllers/HistoryController.java
+++ b/app/femr/ui/controllers/HistoryController.java
@@ -33,6 +33,7 @@ import femr.ui.views.html.partials.history.listTabFieldHistory;
 import femr.util.DataStructure.Mapping.TabFieldMultiMap;
 import femr.util.DataStructure.Mapping.VitalMultiMap;
 import femr.util.stringhelpers.StringUtils;
+import org.joda.time.DateTime;
 import play.data.Form;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -53,14 +54,15 @@ public class HistoryController extends Controller {
     private final ITabService tabService;
     private final IPhotoService photoService;
     private final IVitalService vitalService;
-
+    private IPatientService patientService;
     @Inject
     public HistoryController(IEncounterService encounterService,
                              ISessionService sessionService,
                              ISearchService searchService,
                              ITabService tabService,
                              IPhotoService photoService,
-                             IVitalService vitalService) {
+                             IVitalService vitalService,
+                             IPatientService patientService) {
 
         this.encounterService = encounterService;
         this.sessionService = sessionService;
@@ -68,6 +70,7 @@ public class HistoryController extends Controller {
         this.tabService = tabService;
         this.photoService = photoService;
         this.vitalService = vitalService;
+        this.patientService = patientService;
     }
 
     /**
@@ -275,7 +278,20 @@ public class HistoryController extends Controller {
 
         return ok("true");
     }
+    public Result deletePatientPost(int patientId){
+        CurrentUser currentUser = sessionService.retrieveCurrentUserSession();
 
+        //Getting UserItem
+        ServiceResponse<PatientItem> patientItemResponse= patientService.deletePatient(patientId);
+        if(patientItemResponse.hasErrors())
+            throw new RuntimeException();
+
+        PatientItem patient = patientItemResponse.getResponseObject();
+        patient.setIsDeleted(DateTime.now());
+
+
+        return redirect(routes.TriageController.indexGet());
+    }
     /**
      * Gets the partial view that shows the history of tab field items. Called from AJAX.
      */

--- a/app/femr/ui/controllers/TriageController.java
+++ b/app/femr/ui/controllers/TriageController.java
@@ -16,6 +16,7 @@ import femr.common.models.VitalItem;
 import femr.ui.models.triage.*;
 import femr.ui.views.html.triage.index;
 import femr.util.stringhelpers.StringUtils;
+import org.joda.time.DateTime;
 import play.data.Form;
 import play.mvc.*;
 
@@ -232,6 +233,16 @@ public class TriageController extends Controller {
         return redirect(routes.HistoryController.indexPatientGet(Integer.toString(patientServiceResponse.getResponseObject().getId())));
     }
 
+    public Result deletePatientPost(int patientId){
+        CurrentUser currentUser = sessionService.retrieveCurrentUserSession();
+
+        //Getting UserItem
+        ServiceResponse<PatientItem> patientItemResponse= patientService.deletePatient(patientId);
+        if(patientItemResponse.hasErrors())
+            throw new RuntimeException();
+
+        return redirect(routes.TriageController.indexGet());
+    }
 
     private PatientItem populatePatientItem(IndexViewModelPost viewModelPost, CurrentUser currentUser) {
         PatientItem patient = new PatientItem();

--- a/app/femr/ui/models/history/IndexPatientViewModelGet.java
+++ b/app/femr/ui/models/history/IndexPatientViewModelGet.java
@@ -31,8 +31,6 @@ public class IndexPatientViewModelGet {
     //patient encounters available for the patient
     private List<PatientEncounterItem> patientEncounterItems;
 
-
-
     public List<PatientItem> getPatientItems() {
         return patientItems;
     }

--- a/app/femr/ui/views/history/indexPatient.scala.html
+++ b/app/femr/ui/views/history/indexPatient.scala.html
@@ -64,10 +64,11 @@
                 @for(roles <- currentUser.getRoles()) {
 
                     @if(roles.getId().equals(1) || roles.getId().equals(6) ) {
-                        <span>
                             @helper.form(action = TriageController.deletePatientPost(viewModel.getPatientItem.getId)){
-                                <button type="submit" id="deletePatientBtn" class="btn btn-danger pull-right"> Delete this Patient</button>
+                                <button hidden="true" type="submit"  id="deletePatient"></button>
                             }
+                        <span>
+                            <button type="submit" id="deletePatientBtn" class="btn btn-danger pull-right"> Delete this Patient</button>
                         </span>
                     }
                 }

--- a/app/femr/ui/views/history/indexPatient.scala.html
+++ b/app/femr/ui/views/history/indexPatient.scala.html
@@ -1,3 +1,4 @@
+@import femr.ui.controllers.HistoryController
 @(currentUser: femr.common.dtos.CurrentUser, searchError: java.lang.Boolean, viewModel: femr.ui.models.history.IndexPatientViewModelGet, patientEncounters: List[_ <: femr.common.models.PatientEncounterItem])
 
 @import femr.ui.views.html.layouts.main
@@ -60,7 +61,16 @@
             </div>
             <div id="patientInformation">
                 <h1 class="bold margin-top-zero">Patient Id: @viewModel.getPatientItem.getId</h1>
+                @for(roles <- currentUser.getRoles()) {
 
+                    @if(roles.getId().equals(1) || roles.getId().equals(6) ) {
+                        <span>
+                            @helper.form(action = HistoryController.deletePatientPost(viewModel.getPatientItem.getId())){
+                                <button type="submit" class="btn btn-default pull-right"> Delete this Patient</button>
+                            }
+                        </span>
+                    }
+                }
                 @helper.form(action = TriageController.indexPopulatedGet(viewModel.getPatientItem.getId)) {
                     <button type="submit" class="btn btn-default pull-right">See This Patient In Triage</button>
                 }

--- a/app/femr/ui/views/history/indexPatient.scala.html
+++ b/app/femr/ui/views/history/indexPatient.scala.html
@@ -65,8 +65,8 @@
 
                     @if(roles.getId().equals(1) || roles.getId().equals(6) ) {
                         <span>
-                            @helper.form(action = HistoryController.deletePatientPost(viewModel.getPatientItem.getId())){
-                                <button type="submit" class="btn btn-default pull-right"> Delete this Patient</button>
+                            @helper.form(action = TriageController.deletePatientPost(viewModel.getPatientItem.getId)){
+                                <button type="submit" id="deletePatientBtn" class="btn btn-danger pull-right"> Delete this Patient</button>
                             }
                         </span>
                     }

--- a/conf/evolutions/default/86.sql
+++ b/conf/evolutions/default/86.sql
@@ -6,4 +6,4 @@ ADD COLUMN `isDeleted` DATETIME NULL DEFAULT NULL AFTER `photo_id`;
 # --- !Downs
 
 ALTER TABLE `patients`;
-DROP COLUMN `isDeleted;
+DROP COLUMN `isDeleted`;

--- a/conf/evolutions/default/86.sql
+++ b/conf/evolutions/default/86.sql
@@ -1,0 +1,9 @@
+# --- !Ups
+
+ALTER TABLE `patients`
+ADD COLUMN `isDeleted` DATETIME NULL DEFAULT NULL AFTER `photo_id`;
+
+# --- !Downs
+
+ALTER TABLE `patients`;
+DROP COLUMN `isDeleted;

--- a/conf/routes
+++ b/conf/routes
@@ -54,6 +54,7 @@ GET         /photo/encounter/:id                               @femr.ui.controll
 GET         /triage/:id                                        @femr.ui.controllers.TriageController.indexPopulatedGet(id: Integer)
 GET         /triage                                            @femr.ui.controllers.TriageController.indexGet()
 POST        /triage                                            @femr.ui.controllers.TriageController.indexPost(id: Integer)
+POST        /triage/:id                                        @femr.ui.controllers.TriageController.deletePatientPost(id: Integer)
 #Medical
 POST        /medical/updateVitals/:id                          @femr.ui.controllers.MedicalController.updateVitalsPost(id: Integer)
 GET         /medical/newVitals                                 @femr.ui.controllers.MedicalController.newVitalsGet()

--- a/public/js/history/history.js
+++ b/public/js/history/history.js
@@ -104,6 +104,8 @@ $(document).ready(function () {
     });
 
     $('#deletePatientBtn').click(function () {
-       alert("This patient will be deleted and unsearchable in fEMR. ");
+        if (confirm("Are you sure you want to delete this patient?")) {
+            $("#deletePatient").click();
+        }
     });
 });

--- a/public/js/history/history.js
+++ b/public/js/history/history.js
@@ -102,4 +102,8 @@ $(document).ready(function () {
 
         editEncounterFeature.hideEditDialog();
     });
+
+    $('#deletePatientBtn').click(function () {
+       alert("This patient will be deleted and unsearchable in fEMR. ");
+    });
 });


### PR DESCRIPTION
Added new column for administrators to soft delete patients.  Patients that have been deleted will not be able to be searched in the Home Page, looked up in the Triage section, and the patient will not show up in the research data.