### PR TITLE
[FEMR-207] Fix error that appears whenever you view a past encounter

### DIFF
--- a/app/femr/ui/views/history/indexEncounter.scala.html
+++ b/app/femr/ui/views/history/indexEncounter.scala.html
@@ -171,7 +171,7 @@
                         <p><a class="infoLabel @editClass"> Social History:</a>
                             @dynamicTabSpan(pmhFieldMap.get("socialHistory"))
                         <p><a class="infoLabel @editClass">Current Medications:</a>
-                            @dynamicTabSpan(pmhFieldMap.get("currentMedications"))
+                            @dynamicTabSpan(pmhFieldMap.get("currentMedication"))
                         <p><a class="infoLabel @editClass"> Family History: </a>
                             @dynamicTabSpan(pmhFieldMap.get("familyHistory"))
                     }

--- a/app/femr/ui/views/partials/encounter/dynamicTabSpan.scala.html
+++ b/app/femr/ui/views/partials/encounter/dynamicTabSpan.scala.html
@@ -2,4 +2,6 @@
 
 @import femr.ui.views.html.partials.helpers.outputStringOrNA
 
-<span class="value" data-id="@tabFieldItem.getName"> @outputStringOrNA(tabFieldItem.getValue)</span>
+@if(tabFieldItem != null){
+    <span class="value" data-id="@tabFieldItem.getName"> @outputStringOrNA(tabFieldItem.getValue)</span>
+}


### PR DESCRIPTION
https://teamfemr.atlassian.net/browse/FEMR-207

Fixes an error that was introduced in #485 . Instead of hard coding field names for the map, PR485 started pulling the names from the tab_fields table. These names did not align with the hard coded names in the encounter view. Fixed the name & added a null check