### PR TITLE
[FEMR-209] Let a user prescribe medication without selecting a method…

### DIFF
--- a/app/femr/ui/controllers/MedicalController.java
+++ b/app/femr/ui/controllers/MedicalController.java
@@ -369,6 +369,11 @@ public class MedicalController extends Controller {
 
         for (PrescriptionItem prescriptionItem : prescriptionItemsWithoutID){
 
+            //The POST data sends -1 if an administration ID is not set. Null is more appropriate for the
+            //service layer
+            if (prescriptionItem.getAdministrationID() == -1)
+                prescriptionItem.setAdministrationID(null);
+
             createPrescriptionServiceResponse = medicationService.createPrescriptionWithNewMedication(
                     prescriptionItem.getMedicationName(),
                     prescriptionItem.getAdministrationID(),

--- a/app/femr/ui/controllers/PharmaciesController.java
+++ b/app/femr/ui/controllers/PharmaciesController.java
@@ -194,6 +194,11 @@ public class PharmaciesController extends Controller {
         for(PrescriptionItem script : createViewModelPost.getPrescriptions()) {
 
             if (StringUtils.isNotNullOrWhiteSpace(script.getMedicationName())) {
+                //The POST data sends -1 if an administration ID is not set. Null is more appropriate for the
+                //service layer
+                if (script.getAdministrationID() == -1)
+                    script.setAdministrationID(null);
+
                 //create a new prescription to replace the old prescription.
                 if (script.getAmount() == null){
                     script.setAmount(0);
@@ -201,6 +206,7 @@ public class PharmaciesController extends Controller {
 
                 if (script.getMedicationID() != null){
                     //the medication has already been entered into the medications table (through admin inventory?)
+
                     ServiceResponse<PrescriptionItem> createPrescriptionResponse = medicationService.createPrescription(script.getMedicationID(),
                             script.getAdministrationID(),
                             patientEncounterItem.getId(),


### PR DESCRIPTION
https://teamfemr.atlassian.net/browse/FEMR-209

If a user didn't select an Administration method for a prescription, the value -1 would be sent to the server to indicate this. This was causing an error, so I added a check that changes -1 to null in the controller before being sent to the medication service