### PR TITLE
FEMR240 edit travis.yml to patch javac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,8 @@ scala:
 script: sbt clean compile
 jdk:
    - oraclejdk8
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer


### PR DESCRIPTION
update travis.yml to force Java patch update during Travis CI automated build. First picture is a screenshot of Travis CI with this change and second is without.

https://teamfemr.atlassian.net/browse/FEMR-240



![after](https://cloud.githubusercontent.com/assets/5403109/16538447/ad1c1232-3ff2-11e6-9056-24fbcd87106a.png)
![old_javac](https://cloud.githubusercontent.com/assets/5403109/16538448/ad2437a0-3ff2-11e6-801d-f1ee79d5ae11.png)