### PR TITLE
[FEMR237] add evolution to align play_evolutions table

### DIFF
--- a/conf/evolutions/default/99.sql
+++ b/conf/evolutions/default/99.sql
@@ -1,0 +1,13 @@
+# --- !Ups
+
+ALTER TABLE `play_evolutions`
+CHANGE COLUMN `apply_script` `apply_script` MEDIUMTEXT NULL DEFAULT NULL ,
+CHANGE COLUMN `revert_script` `revert_script` MEDIUMTEXT NULL DEFAULT NULL ,
+CHANGE COLUMN `last_problem` `last_problem` MEDIUMTEXT NULL DEFAULT NULL ;
+
+# --- !Downs
+
+ALTER TABLE `play_evolutions`
+CHANGE COLUMN `apply_script` `apply_script` TEXT NULL DEFAULT NULL ,
+CHANGE COLUMN `revert_script` `revert_script` TEXT NULL DEFAULT NULL ,
+CHANGE COLUMN `last_problem` `last_problem` TEXT NULL DEFAULT NULL ;


### PR DESCRIPTION
Found this while working on a bigger issue detailed in the comments here:

https://teamfemr.atlassian.net/browse/FEMR-237

Play Framework started generating the play_evolutions table with a different datatype so this will sync up all of our old databases.
