### PR TITLE
[FEMR-251] Add script to retain diabetes prompt data during upgrade f…

### DIFF
--- a/conf/scripts/upgrade_from_218.sql
+++ b/conf/scripts/upgrade_from_218.sql
@@ -1,4 +1,4 @@
-##Creates a back up of values that are deleted during a 2.1.8 to 2.2.x upgrade
+## Creates a back up of values that are deleted during a 2.1.8 to 2.2.x upgrade
 # Evolutions cause a destructive drop and recreation of 2 columns in the
 # patient_encounters table##
 
@@ -11,7 +11,7 @@ CREATE TABLE `temp` (
   `id` int(11) NOT NULL,
   `user_id_diabetes_screen` int(11) DEFAULT NULL,
   `date_of_diabetes_screen` datetime DEFAULT NULL
-)
+);
 
 -- Load the table
 INSERT INTO `temp` (`id`, `user_id_diabetes_screen`, `date_of_diabetes_screen`)

--- a/conf/scripts/upgrade_from_220.sql
+++ b/conf/scripts/upgrade_from_220.sql
@@ -1,0 +1,31 @@
+## Creates a back up of values that are deleted during a 2.2.0 to 2.2.x upgrade
+# Evolutions cause a destructive drop and recreation of 1 column in the
+# patient_encounters table##
+
+
+#----- RUN BEFORE UPGRADE -----#
+
+-- Create a new table as a back up for values that are going to be
+-- deleted during the evolution
+CREATE TABLE `temp` (
+  `id` int(11) NOT NULL,
+  `is_diabetes_screened` tinyint(1) DEFAULT NULL
+);
+
+-- Load the table
+INSERT INTO `temp` (`id`, `is_diabetes_screened`)
+SELECT `id`, `is_diabetes_screened`
+FROM `patient_encounters`;
+
+
+
+#----- RUN AFTER UPGRADE -----#
+
+-- Restore the proper values
+UPDATE `patient_encounters`
+INNER JOIN `temp`
+ON `patient_encounters`.`id` = `temp`.`id`
+SET `patient_encounters`.`is_diabetes_screened` = `temp`.`is_diabetes_screened`;
+
+-- Clean up the mess you made
+DROP TABLE `temp`;


### PR DESCRIPTION
Evolutions were merged into existing evolutions which require a full execution of a down after being changed. This one in particular was evolution 98.

https://teamfemr.atlassian.net/browse/FEMR-251