### PR TITLE
[FEMR-151] Add age group and age value validation in triage (frontend)

### DIFF
--- a/public/js/triage/triageClientValidation.js
+++ b/public/js/triage/triageClientValidation.js
@@ -26,7 +26,59 @@ var triageFieldValidator = {
             //nothing has been filled out
             $('#ageClassificationWrap').css('border', '1px solid red');
             triageFieldValidator.isValid = false;
-        } else {
+
+        } else if ((patientInformation.months.val() || patientInformation.years.val()) && patientInformation.ageClassification.filter(':checked').val()) {
+            var months;
+            if(!patientInformation.months.val()){
+                months = "0";
+            }else{
+               months =  patientInformation.months.val();
+            }
+            var years;
+            if(!patientInformation.years.val()){
+                years = "0";
+            }else{
+                years = patientInformation.years.val();
+            }
+            var totalAge = parseFloat(years) + (parseFloat(months) / 12);
+            var ageGroupYearMatch = true;
+
+            switch (patientInformation.ageClassification.filter(':checked').val()){
+                case 'infant':
+                    if (totalAge >= 2) {
+                        ageGroupYearMatch = false;
+                    }
+                    break;
+                case 'child':
+                    if ((totalAge < 2) || (totalAge >= 13) ){
+                        ageGroupYearMatch = false;
+                    }
+                    break;
+                case 'teen':
+                    if ((totalAge < 13) || (totalAge >= 18)){
+                        ageGroupYearMatch = false;
+                    }
+                    break;
+                case 'adult':
+                    if ((totalAge < 18) || (totalAge >= 65)){
+                        ageGroupYearMatch = false;
+                    }
+                    break;
+                case 'elder':
+                    if (totalAge < 65){
+                        ageGroupYearMatch = false;
+                    }
+                    break;
+            }
+            if (ageGroupYearMatch){
+                $('#ageClassificationWrap').css('border', 'none');
+            }
+            else {
+                $('#ageClassificationWrap').css('border', '1px solid red');
+                triageFieldValidator.isValid = false;
+            }
+        }
+        else{
             //something has been filled out
             $('#ageClassificationWrap').css('border', 'none');
         }


### PR DESCRIPTION
Implements error checking on client side to detect a mismatch
between the entered age and age group during triage.

Years and months are used to compute age, and this age is then compared with the given thresholds.
There is an small validation that checks when the user does not provide years or months (so it assigns a default value of 0)

The form cannot be submitted until the inconsistency is solved.

Contributed by Jarrod Moore during the CEN5035 course at FSU

https://teamfemr.atlassian.net/browse/FEMR-151