### PR TITLE
[FEMR-208] Display prescription amount in encounter's PDF

### DIFF
--- a/app/femr/ui/controllers/PDFController.java
+++ b/app/femr/ui/controllers/PDFController.java
@@ -436,6 +436,11 @@ public class PDFController extends Controller {
 
             table.addCell(cell);
 
+            //[FEMR-208] Contributed by Xiaoxiao Gan during the CEN5035 course at FSU
+            Paragraph AmountTitle = new Paragraph("Amount", getTitleFont());
+            cell = new PdfPCell(AmountTitle);
+            table.addCell(cell);
+
             table.completeRow();
 
             for (PrescriptionItem prescription : prescriptionItems) {
@@ -453,6 +458,12 @@ public class PDFController extends Controller {
                     Paragraph replacedMedName = new Paragraph(prescription.getName(), getValueFont());
                     cell = new PdfPCell(replacedMedName);
                     table.addCell(cell);
+
+                    //[FEMR-208] Contributed by Xiaoxiao Gan during the CEN5035 course at FSU
+                    Paragraph Amount = new Paragraph(Integer.toString(prescription.getAmount()));
+                    cell = new PdfPCell(Amount);
+                    table.addCell(cell);
+
                 } else {
                     Paragraph medName = new Paragraph(prescription.getName(), getValueFont());
                     cell = new PdfPCell(medName);
@@ -460,6 +471,11 @@ public class PDFController extends Controller {
 
                     Paragraph blankCell = new Paragraph(" ", getValueFont());
                     cell = new PdfPCell(blankCell);
+                    table.addCell(cell);
+
+                    //[FEMR-208] Contributed by Xiaoxiao Gan during the CEN5035 course at FSU
+                    Paragraph Amount = new Paragraph(Integer.toString(prescription.getAmount()));
+                    cell = new PdfPCell(Amount);
                     table.addCell(cell);
                 }
                 table.completeRow();


### PR DESCRIPTION
Get the prescription amount value and display it in the dispensed
prescription part of the generated PDF.

PDFController now adds a new column to the report with the amount dispensed.

//TODO: Please verify the behavior of this change with replaced medications. Not sure if the current output is the expected one.

 Contributed by Xiaoxiao Gan during the CEN5035 course at FSU