### PR TITLE
[FEMR-5] Fix - age cannot be updated in later encounters

### DIFF
--- a/app/femr/business/services/core/IPatientService.java
+++ b/app/femr/business/services/core/IPatientService.java
@@ -21,6 +21,7 @@ package femr.business.services.core;
 import femr.common.dtos.ServiceResponse;
 import femr.common.models.PatientItem;
 
+import java.util.Date;
 import java.util.Map;
 
 public interface IPatientService {
@@ -34,15 +35,16 @@ public interface IPatientService {
     ServiceResponse<Map<String,String>> retrieveAgeClassifications();
 
     /**
-     * Updates a patients sex if that patient does not previously have one assigned. If sex is null then it just gets and
-     * returns the patient.
+     * Updates a patients sex and age if that patient does not previously have one assigned. If sex or age is null then it just sets
+     * whichever field is available, then gets and returns the patient.
      *
      * @param id the id of the patient, not null
      * @param sex the sex of the patient, may be null
+     * @param age the age of the patient, may be null
      * @return a service response that contains a PatientItem representing the patient that was updated
      * and/or errors if they exist.
      */
-    ServiceResponse<PatientItem> updateSex(int id, String sex);
+    ServiceResponse<PatientItem> updateSexAndAge(int id, String sex, Date age);
 
     /**
      * Creates a new patient.

--- a/app/femr/business/services/system/PatientService.java
+++ b/app/femr/business/services/system/PatientService.java
@@ -31,6 +31,7 @@ import org.joda.time.DateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Date;
 
 public class PatientService implements IPatientService {
 
@@ -76,7 +77,7 @@ public class PatientService implements IPatientService {
      * {@inheritDoc}
      */
     @Override
-    public ServiceResponse<PatientItem> updateSex(int id, String sex) {
+    public ServiceResponse<PatientItem> updateSexAndAge(int id, String sex, Date age) {
 
         ServiceResponse<PatientItem> response = new ServiceResponse<>();
 
@@ -89,12 +90,16 @@ public class PatientService implements IPatientService {
                 response.addError("exception", "Patient Not Found");
                 return response;
             }
-
+            if(age!=null){
+                savedPatient.setAge(age);
+                savedPatient = patientRepository.savePatient(savedPatient);
+            }
             // sex can be changed, but not set to null
             if(StringUtils.isNotNullOrWhiteSpace(sex)) {
                 savedPatient.setSex(sex);
                 savedPatient = patientRepository.savePatient(savedPatient);
             }
+
 
             String photoPath = null;
             Integer photoId = null;

--- a/app/femr/ui/controllers/TriageController.java
+++ b/app/femr/ui/controllers/TriageController.java
@@ -163,7 +163,7 @@ public class TriageController extends Controller {
             patientItem = populatePatientItem(viewModel, currentUser);
             patientServiceResponse = patientService.createPatient(patientItem);
         } else {
-            patientServiceResponse = patientService.updateSex(id, viewModel.getSex());
+            patientServiceResponse = patientService.updateSexAndAge(id, viewModel.getSex(), viewModel.getAge());
         }
         if (patientServiceResponse.hasErrors()) {
             throw new RuntimeException();


### PR DESCRIPTION
The specification of IPatientService and  PatientService was slightly changed in order to support age update.
Hope this change does not impact future plans.

Now the age can be updated as expected.

Contributed by Raghunath Thota during the CEN5035 course at FSU

https://teamfemr.atlassian.net/browse/FEMR-5