### PR TITLE
[FEMR-287] Let a user delete a patient encounter

### DIFF
--- a/app/femr/business/services/core/IEncounterService.java
+++ b/app/femr/business/services/core/IEncounterService.java
@@ -127,5 +127,13 @@ public interface IEncounterService {
      *@return List of PatientEncounterItems who were checked in on the current Day
      */
     ServiceResponse<List<PatientEncounterItem>> retrieveCurrentDayPatientEncounters(int tripID);
-
+    /**
+     * Soft Delete of a patient encounter.
+     * @param encounterId id of the encounter for the patient
+     * @param patientId id of the patient
+     * @param userId id of the user deleting the encounter
+     * @param reason the reason for deleting the encounter
+     * @return deleted encounter and/or error if any occur
+     */
+    ServiceResponse<PatientEncounterItem> deleteEncounter(int encounterId, int patientId, int userId, String reason);
 }

--- a/app/femr/business/services/system/EncounterService.java
+++ b/app/femr/business/services/system/EncounterService.java
@@ -559,4 +559,34 @@ public class EncounterService implements IEncounterService {
 
         return tabFieldId;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ServiceResponse<PatientEncounterItem> deleteEncounter(int encounterId, int patientId, int userId, String reason){
+        ServiceResponse<PatientEncounterItem> response = new ServiceResponse<>();
+
+        if (StringUtils.isNullOrWhiteSpace(reason)) {
+            response.addError("", "reason not provided");
+            return response;
+        }
+        //might need to add patientId
+        ExpressionList<PatientEncounter> patientEncounterQuery = QueryProvider.getPatientEncounterQuery()
+                .where()
+                .eq("patient_id", patientId)
+                .eq("id", encounterId);
+
+        try{
+           IPatientEncounter savedEncounter = patientEncounterRepository.findOne(patientEncounterQuery);//.findOne(patientEncounterQuery);
+            savedEncounter.setIsEncounterDeleted(DateTime.now());
+            savedEncounter.setDeletedEncounterByUserId(userId);
+            savedEncounter.setReasonEncounterDeleted(reason);
+            patientEncounterRepository.update(savedEncounter);
+        }catch (Exception ex) {
+            response.addError("exception", ex.getMessage());
+        }
+
+        return response;
+    }
 }

--- a/app/femr/business/services/system/SearchService.java
+++ b/app/femr/business/services/system/SearchService.java
@@ -178,6 +178,7 @@ public class SearchService implements ISearchService {
 
         ExpressionList<PatientEncounter> patientEncounterQuery = QueryProvider.getPatientEncounterQuery()
                 .where()
+                .isNull("isEncounterDeleted")
                 .eq("id", encounterId);
 
         try {
@@ -242,6 +243,7 @@ public class SearchService implements ISearchService {
         }
         ExpressionList<PatientEncounter> patientEncounterQuery = QueryProvider.getPatientEncounterQuery()
                 .where()
+                .isNull("isEncounterDeleted")
                 .eq("id", encounterId);
 
         try {
@@ -266,6 +268,7 @@ public class SearchService implements ISearchService {
         }
         Query<PatientEncounter> query = QueryProvider.getPatientEncounterQuery()
                 .where()
+                .isNull("isEncounterDeleted")
                 .eq("patient_id", patientId)
                 .order()
                 .asc("date_of_triage_visit");
@@ -294,6 +297,7 @@ public class SearchService implements ISearchService {
         ServiceResponse<List<PatientEncounterItem>> response = new ServiceResponse<>();
         Query<PatientEncounter> query = QueryProvider.getPatientEncounterQuery()
                 .where()
+                .isNull("isEncounterDeleted")
                 .eq("patient_id", patientId)
                 .order()
                 .desc("date_of_triage_visit");

--- a/app/femr/data/models/core/IPatientEncounter.java
+++ b/app/femr/data/models/core/IPatientEncounter.java
@@ -75,4 +75,16 @@ public interface IPatientEncounter {
     Boolean getIsDiabetesScreened();
 
     void setIsDiabetesScreened(Boolean isDiabetesScreened);
+
+    DateTime getIsEncounterDeleted();
+
+    void setIsEncounterDeleted(DateTime isDeleted);
+
+    Integer getDeletedEncounterByUserId() ;
+
+    void setDeletedEncounterByUserId(Integer userId) ;
+
+    String getReasonEncounterDeleted() ;
+
+    void setReasonEncounterDeleted(String reason) ;
 }

--- a/app/femr/data/models/mysql/PatientEncounter.java
+++ b/app/femr/data/models/mysql/PatientEncounter.java
@@ -65,6 +65,12 @@ public class PatientEncounter implements IPatientEncounter {
     private User diabetesScreener;
     @Column(name="is_diabetes_screened", nullable = true)
     private Boolean isDiabetesScreened;
+    @Column(name = "isEncounterDeleted", nullable = true)
+    private DateTime isEncounterDeleted;
+    @Column(name = "deleted_encounter_by_user_id", unique = false, nullable = true)
+    private Integer deletedEncounterByUserId;
+    @Column(name = "reason_encounter_deleted", nullable = true)
+    private String reasonEncounterDeleted;
 
     @Override
     public int getId() {
@@ -202,4 +208,22 @@ public class PatientEncounter implements IPatientEncounter {
 
     @Override
     public void setIsDiabetesScreened(Boolean isDiabetesScreened) {this.isDiabetesScreened = isDiabetesScreened;}
+
+    @Override
+    public DateTime getIsEncounterDeleted(){return isEncounterDeleted;}
+
+    @Override
+    public void setIsEncounterDeleted(DateTime isDeleted){this.isEncounterDeleted = isDeleted;}
+
+    @Override
+    public Integer getDeletedEncounterByUserId(){return deletedEncounterByUserId;}
+
+    @Override
+    public void setDeletedEncounterByUserId(Integer userId){this.deletedEncounterByUserId = userId;}
+
+    @Override
+    public String getReasonEncounterDeleted(){return reasonEncounterDeleted;}
+
+    @Override
+    public void setReasonEncounterDeleted(String reason){this.reasonEncounterDeleted = reason;}
 }

--- a/app/femr/ui/controllers/TriageController.java
+++ b/app/femr/ui/controllers/TriageController.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.inject.Inject;
 import femr.business.services.core.*;
+import femr.business.services.system.EncounterService;
 import femr.common.dtos.CurrentUser;
 import femr.common.dtos.ServiceResponse;
 import femr.common.models.*;
@@ -263,12 +264,26 @@ public class TriageController extends Controller {
         final Form<DeleteViewModelPost> DeleteViewModelForm = formFactory.form(DeleteViewModelPost.class);
         DeleteViewModelPost reasonDeleted = DeleteViewModelForm.bindFromRequest().get();
         //Getting UserItem
-        ServiceResponse<PatientItem> patientItemResponse= patientService.deletePatient(patientId, currentUser.getId(), reasonDeleted.getReasonDeleted());
+        ServiceResponse<PatientItem> patientItemResponse = patientService.deletePatient(patientId, currentUser.getId(), reasonDeleted.getReasonDeleted());
 
         if(patientItemResponse.hasErrors())
             throw new RuntimeException();
 
         return redirect(routes.TriageController.indexGet());
+    }
+
+    public Result deleteEncounterPost(int encounterId, int patientId){
+        CurrentUser currentUser = sessionService.retrieveCurrentUserSession();
+
+        final Form<DeleteViewModelPost> DeleteViewModelForm = formFactory.form(DeleteViewModelPost.class);
+        DeleteViewModelPost reasonDeleted = DeleteViewModelForm.bindFromRequest().get();
+
+        ServiceResponse<PatientEncounterItem> patientItemResponse = encounterService.deleteEncounter(encounterId, patientId, currentUser.getId(), reasonDeleted.getReasonDeleted());
+
+        if(patientItemResponse.hasErrors())
+            throw new RuntimeException();
+
+        return redirect(routes.HistoryController.indexPatientGet(Integer.toString(patientId)));
     }
 
     private boolean isDiabetesPromptTurnedOn(){

--- a/app/femr/ui/views/history/indexEncounter.scala.html
+++ b/app/femr/ui/views/history/indexEncounter.scala.html
@@ -1,4 +1,5 @@
 @(currentUser: femr.common.dtos.CurrentUser, viewModel: femr.ui.models.history.IndexEncounterViewModel, viewModelMedical: femr.ui.models.history.IndexEncounterMedicalViewModel, viewModelPharmacy: femr.ui.models.history.IndexEncounterPharmacyViewModel)
+@roles = @{currentUser.getRoles().map(r => r.getId())}
 
     @import femr.ui.views.html.layouts.main
     @import femr.ui.views.html.partials.helpers.outputStringOrNA
@@ -13,6 +14,8 @@
 
     @import collection.JavaConversions._
     @import femr.ui.controllers.routes.PDFController
+    @import femr.ui.controllers.routes.TriageController
+    @import femr.data.models.mysql.Roles
 
 
     @additionalScripts = {
@@ -32,6 +35,15 @@
         <div class="sectionBackground backgroundForWrap" id="encounterViewWrap">
             <div id="encounterViewHeader">
 
+                @if(roles.contains(Roles.ADMINISTRATOR) || roles.contains(Roles.SUPERUSER) ) {
+                    @helper.form(action = TriageController.deleteEncounterPost(viewModel.getPatientEncounterItem.getId, viewModel.getPatientItem.getId)){
+                        <input type="hidden" name="reasonDeleted" id="reasonDeleted" />
+                        <button hidden="true" type="submit"  id="deleteEncounter"></button>
+                    }
+                    <span>
+                        <button type="submit" id="deleteEncounterBtn" class="btn btn-danger pull-right"> Delete this Encounter</button>
+                    </span>
+                }
 
                 <img class="" height="90" width="90" src="@viewModel.getPatientItem.getPathToPhoto" />
                 <p>@viewModel.getPatientItem.getFirstName @viewModel.getPatientItem.getLastName

--- a/app/femr/ui/views/triage/index.scala.html
+++ b/app/femr/ui/views/triage/index.scala.html
@@ -41,6 +41,8 @@
         @helper.form(action = TriageController.indexPost(viewModel.getPatient.getId), 'class -> "form-horizontal", 'enctype -> "multipart/form-data") {
             <div id="genInfoWrap" class="sectionBackground backgroundForWrap">
 
+                <input class="hidden" type="text" id="patientId" value="viewModel.getPatient.getId"/>
+
                 <h2>General Info</h2>
 
                 @inputText("First Name", "firstName", true, if(viewModel != null) viewModel.getPatient.getFirstName else null, "text")

--- a/app/femr/ui/views/triage/index.scala.html
+++ b/app/femr/ui/views/triage/index.scala.html
@@ -41,7 +41,7 @@
         @helper.form(action = TriageController.indexPost(viewModel.getPatient.getId), 'class -> "form-horizontal", 'enctype -> "multipart/form-data") {
             <div id="genInfoWrap" class="sectionBackground backgroundForWrap">
 
-                <input class="hidden" type="text" id="patientId" value="viewModel.getPatient.getId"/>
+                <input class="hidden" type="text" id="patientId" value="@viewModel.getPatient.getId" />
 
                 <h2>General Info</h2>
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -22,7 +22,7 @@ play.il8n.langs="en"
 #Register MySQL database settings
 db.default.driver="com.mysql.jdbc.Driver"
 db.default.url="jdbc:mysql://localhost/femr?characterEncoding=UTF-8"
-db.default.username="sa"
+db.default.username="sal"
 db.default.password=""
 db.default.logStatements=false
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -22,7 +22,7 @@ play.il8n.langs="en"
 #Register MySQL database settings
 db.default.driver="com.mysql.jdbc.Driver"
 db.default.url="jdbc:mysql://localhost/femr?characterEncoding=UTF-8"
-db.default.username="sal"
+db.default.username="sa"
 db.default.password=""
 db.default.logStatements=false
 

--- a/conf/evolutions/default/103.sql
+++ b/conf/evolutions/default/103.sql
@@ -1,0 +1,21 @@
+# --- !Ups
+
+ALTER TABLE `patient_encounters`
+ADD COLUMN `isEncounterDeleted` DATETIME NULL DEFAULT NULL AFTER `is_diabetes_screened`;
+
+ALTER TABLE `patient_encounters`
+ADD COLUMN `deleted_encounter_by_user_id` INT(11) NULL DEFAULT NULL  AFTER `isEncounterDeleted`;
+
+ALTER TABLE `patient_encounters`
+ADD COLUMN `reason_encounter_deleted` VARCHAR(255) NULL DEFAULT NULL AFTER `deleted_encounter_by_user_id`;
+
+# --- !Downs
+
+ALTER TABLE `patient_encounters`
+DROP COLUMN `isEncounterDeleted`;
+
+ALTER TABLE `patient_encounters`
+DROP COLUMN `deleted_encounter_by_user_id`;
+
+ALTER TABLE `patient_encounters`
+DROP COLUMN `reason_encounter_deleted`;

--- a/conf/routes
+++ b/conf/routes
@@ -61,7 +61,7 @@ GET         /triage/:id                                        @femr.ui.controll
 GET         /triage                                            @femr.ui.controllers.TriageController.indexGet()
 POST        /triage                                            @femr.ui.controllers.TriageController.indexPost(id: Integer)
 POST        /triage/:id                                        @femr.ui.controllers.TriageController.deletePatientPost(id: Integer)
-
+POST        /triage/:encounterid/:patientid                    @femr.ui.controllers.TriageController.deleteEncounterPost(encounterid: Integer, patientid: Integer)
 #Medical
 POST        /medical/updateVitals/:id                          @femr.ui.controllers.MedicalController.updateVitalsPost(id: Integer)
 GET         /medical/newVitals                                 @femr.ui.controllers.MedicalController.newVitalsGet()

--- a/public/js/history/history.js
+++ b/public/js/history/history.js
@@ -116,4 +116,19 @@ $(document).ready(function () {
             }
         } while (reason === "");
     });
+
+    //this is used to delete an encounter
+    $('#deleteEncounterBtn').click(function () {
+        var msg = "Please enter the reason for deleting this encounter below:";
+        var reason;
+
+        do {
+            if (reason = prompt(msg)) {
+                $('#reasonDeleted').val(reason);
+                $("#deleteEncounter").click();
+            } else if (!msg.includes('***')) {
+                msg += "\n\n***A reason must be provided in order to delete a patient encounter***";
+            }
+        } while (reason === "");
+    });
 });

--- a/public/js/triage/triage.js
+++ b/public/js/triage/triage.js
@@ -655,11 +655,15 @@ $(document).ready(function () {
         var patientInfo = triageFields.patientInformation;
         var query = patientInfo.firstName.val() + " " + patientInfo.lastName.val();
         var url = "/search/check/" + query;
+        var patientId = $("#patientId").val();
+
         $.getJSON(url, function (result) {
             if (result === true) {
-                if (confirm("A patient with this name already exists in the database. Would you like to view the matching patient information?")) {
-                    var duplicatePatientUrl = "/history/patient/" + patientInfo.firstName.val() + "-" + patientInfo.lastName.val();
-                    window.location.replace(duplicatePatientUrl);
+                if(!(patientId > 0)) {
+                    if (confirm("A patient with this name already exists in the database. Would you like to view the matching patient information?")) {
+                        var duplicatePatientUrl = "/history/patient/" + patientInfo.firstName.val() + "-" + patientInfo.lastName.val();
+                        window.location.replace(duplicatePatientUrl);
+                    }
                 }
             }
         })


### PR DESCRIPTION
Implemented a Delete Encounter Button in the encounter history page. Once an administrator or superuser clicks on an encounter, they will have the option to delete the encounter in the top right corner. This is a soft delete which records the time, date, user id, and reason for the delete in columns that were created in the `patient_encounters` database. This pull request includes the commits from pull request #594 as well. 