### PR TITLE
Built upon previous push for this bug but this time I made it so that…

### DIFF
--- a/app/femr/ui/views/history/indexEncounter.scala.html
+++ b/app/femr/ui/views/history/indexEncounter.scala.html
@@ -70,12 +70,42 @@
                             </p>
                         }
 
-                        <p><span class="infoLabel">Height:</span> @outputHeightOrNA(
-                            String.valueOf(patient.getHeightFeet),
-                            String.valueOf(patient.getHeightInches),
-                            viewModelMedical.getSettings.isMetric
-                        )</p>
-                        <p><span class="infoLabel">Weight:</span> @outputWeightOrNA(String.valueOf(patient.getWeight), viewModelMedical.getSettings.isMetric)</p>
+                        <p><span class="infoLabel">Height:</span>
+                            @defining(viewModelMedical.getVitalList) { vitalMap =>
+                                @for(dateIndex <- 1 to vitalMap.getDateListChronological.size) {
+                                    @if(viewModelMedical.getSettings.isMetric) {
+                                        @outputHeightOrNA(
+                                            vitalMap.get("heightMeters", vitalMap.getDate(dateIndex - 1)),
+                                            vitalMap.get("heightCm", vitalMap.getDate(dateIndex - 1)),
+                                            viewModelMedical.getSettings.isMetric,
+                                            ""
+                                        )}else {
+                                        @outputHeightOrNA(
+                                            vitalMap.get("heightFeet", vitalMap.getDate(dateIndex - 1)),
+                                            vitalMap.get("heightInches", vitalMap.getDate(dateIndex - 1)),
+                                            viewModelMedical.getSettings.isMetric,
+                                            ""
+                                        )
+                                    }
+                                }
+                        </p>
+
+                        <p><span class="infoLabel">Weight:</span>
+                        @for(dateIndex <- 1 to vitalMap.getDateListChronological.size) {
+
+                            @if(viewModelMedical.getSettings.isMetric) {
+                                @outputWeightOrNA(vitalMap.get("weightKgs", vitalMap.getDate(dateIndex - 1)), viewModelMedical.getSettings.isMetric, "")
+
+                            } else {
+                                @outputWeightOrNA(vitalMap.get("weight", vitalMap.getDate(dateIndex - 1)), viewModelMedical.getSettings.isMetric, "")
+
+                            }
+
+                            }
+
+                        </p>
+
+                    }
                     </div>
                 }
                     </div>
@@ -106,14 +136,15 @@
 
                 <div class="encounterViewBodyRight">
                 @defining(viewModelMedical.getVitalList) { vitalMap =>
-                    <p>
-                        <span class="infoLabel">Temperature:</span>
+                    <p><span class="infoLabel">Temperature:</span>
+                    @for(dateIndex <- 1 to vitalMap.getDateListChronological.size) {
+                        @if(viewModelMedical.getSettings.isMetric) {
+                            @outputTemperatureOrNA(vitalMap.get("temperatureCelsius", vitalMap.getDate(dateIndex - 1)), viewModelMedical.getSettings.isMetric, "")
+                        } else {
+                            @outputTemperatureOrNA(vitalMap.get("temperature", vitalMap.getDate(dateIndex - 1)), viewModelMedical.getSettings.isMetric, "")
 
-                        @for(dateIndex <- 1 to vitalMap.getDateListChronological.size) {
-                            <span>
-                            @outputTemperatureOrNA(vitalMap.get("temperature", vitalMap.getDate(dateIndex - 1)), viewModelMedical.getSettings.isMetric)
-                            </span>
                         }
+                    }
                         </p>
 
                     <p>


### PR DESCRIPTION
… the encounter values for weight now come from the vitals map

Their was a slight discrepancy in the way that height data was displayed in the medical view when compared to how it was displayed in the encounter view. The problem was due to the fact that data in the medical viewer display was pulled from the vitals map whereas data in the encounter view display was being pulled from the class patientvitals where it was being stored as in int. The encounter view display is now pulling values from the vitals map and displays the correct value for all encounters.

This version of the push made it so the value for weight in encounter is also drawn from the patient vitals map.