### PR TITLE
FEMR-337 - Fixes bug with viewing null quantity prescription encounters

### DIFF
--- a/app/femr/common/ItemModelMapper.java
+++ b/app/femr/common/ItemModelMapper.java
@@ -370,7 +370,7 @@ public class ItemModelMapper implements IItemModelMapper {
         if (medicationItem != null) {
             if (medicationItem.getQuantityCurrent() == null)
                 prescriptionItem.setFormularyMessage("Medication is not found in the formulary");
-            else if (amount > medicationItem.getQuantityCurrent())
+            else if (amount != null && amount > medicationItem.getQuantityCurrent())
                 prescriptionItem.setFormularyMessage("Not Enough Medication Remaining to Dispense!");
         } else {
             prescriptionItem.setFormularyMessage("Medication is not found in the formulary");


### PR DESCRIPTION
This fixes an immediate error, but brings up the question of should prescription inventories ever not be an integer? Would a `null` value ever be needed? We can fix the small hole here, but it may be worth considering some more validation or forcing quantity to default to 0.

