### PR TITLE
FEMR-336 - Fixed problem with creating tab fields on a new encounter

### DIFF
--- a/app/femr/business/services/system/EncounterService.java
+++ b/app/femr/business/services/system/EncounterService.java
@@ -253,8 +253,7 @@ public class EncounterService implements IEncounterService {
                     .isNull("isDeleted");
             ExpressionList<ChiefComplaint> chiefComplaintExpressionList = QueryProvider.getChiefComplaintQuery()
                     .where()
-                    .eq("patient_encounter_id", encounterId)
-                    .isNull("isDeleted");
+                    .eq("patient_encounter_id", encounterId);
 
             //the object we will use to populate to put in the ServiceResponse
             List<TabFieldItem> tabFieldItemsForResponse;


### PR DESCRIPTION
I can't find any evidence that `isDeleted` was ever added to the `cheif_complaints` table, so I think this code was errantly added in FEMR-287

https://github.com/FEMR/femr/commit/3fd6e187d29eaa234a74df0e1b19e542b703282c#diff-8590efd0690401d52100c4fb74a18040R257