### PR TITLE
[FEMR-253] Prevent deleted medication from displaying on typeahead

### DIFF
--- a/app/femr/data/daos/system/MedicationRepository.java
+++ b/app/femr/data/daos/system/MedicationRepository.java
@@ -204,6 +204,7 @@ public class MedicationRepository implements IMedicationRepository {
                     .where()
                     .eq("medicationInventory.missionTrip.id", tripId)
                     .isNotNull("conceptMedicationForm")
+                    .isNull("medicationInventory.isDeleted")
                     .gt("medicationInventory.quantityCurrent", 0)
                     .orderBy("name");
 


### PR DESCRIPTION
Completed [FEMR-253] where a bug existed which incorrectly displayed deleted medication in the typeahead on the medical page.