### PR TITLE
Fix error occuring with new inventory medication is added

### DIFF
--- a/app/femr/business/services/core/IInventoryService.java
+++ b/app/femr/business/services/core/IInventoryService.java
@@ -89,7 +89,7 @@ public interface IInventoryService {
      * @param tripId id of the trip that will contain or contains the medication.
      * @return a medication item that contains quantity information.
      */
-    ServiceResponse<MedicationItem> createInventoryMedication(int medicationId, int tripId);
+    ServiceResponse<MedicationItem> createMedicationInventory(int medicationId, int tripId);
 
     /**
      * Deletes (soft-deletes) inventory medication by medication/tripId.

--- a/app/femr/business/services/core/IInventoryService.java
+++ b/app/femr/business/services/core/IInventoryService.java
@@ -69,6 +69,19 @@ public interface IInventoryService {
     ServiceResponse<MedicationItem> setQuantityCurrent(int medicationId, int tripId, int quantityCurrent);
 
     /**
+     * Checks whether a medication has been added to the trip inventory at some point.
+     * Returns ServiceResponse<Boolean> with Boolean set as true if the medication was at some point
+     * added to the inventory (regardless of soft-deletion state).
+     * Returns ServiceResponse<Boolean> with Boolean set as false if the medication has never been added
+     * to that trip's inventory
+     *
+     * @param medicationId
+     * @param tripId
+     * @return ServiceResponse with boolean object as to whether the medication was ever added to the given trip inventory
+     */
+    ServiceResponse<Boolean> existsInventoryMedicationInTrip(int medicationId, int tripId);
+
+    /**
      * Adds a new medication to the trip inventory if it is not yet there,
      * or undoes the soft delete of a medication already added to a trip inventory
      *
@@ -76,7 +89,7 @@ public interface IInventoryService {
      * @param tripId id of the trip that will contain or contains the medication.
      * @return a medication item that contains quantity information.
      */
-    ServiceResponse<MedicationItem> createMedicationInventory(int medicationId, int tripId);
+    ServiceResponse<MedicationItem> createInventoryMedication(int medicationId, int tripId);
 
     /**
      * Deletes (soft-deletes) inventory medication by medication/tripId.

--- a/app/femr/business/services/system/InventoryService.java
+++ b/app/femr/business/services/system/InventoryService.java
@@ -146,6 +146,29 @@ public class InventoryService implements IInventoryService {
         return response;
     }
 
+    /**
+     * @{inheritDoc}
+     */
+    public ServiceResponse<Boolean> existsInventoryMedicationInTrip(int medicationId, int tripId){
+        ServiceResponse<Boolean> response = new ServiceResponse<>();
+        IMedicationInventory medicationInventory;
+
+        boolean existsInTrip = false;
+        try{
+            medicationInventory = medicationRepository.retrieveMedicationInventoryByMedicationIdAndTripId(medicationId, tripId);
+            if(medicationInventory != null){
+                response.setResponseObject(new Boolean(true));
+            } else {
+                response.setResponseObject(new Boolean(false));
+            }
+        } catch (Exception ex) {
+            response.addError("", ex.getMessage());
+        }
+
+        return response;
+
+    }
+
 
     /**
     *{@inheritDoc}
@@ -165,8 +188,6 @@ public class InventoryService implements IInventoryService {
             medicationItem = itemModelMapper.createMedicationItem(medicationInventory.getMedication(),  medicationInventory.getQuantityCurrent(), medicationInventory.getQuantityInitial(), null, null, null);
 
             response.setResponseObject(medicationItem);
-        } catch (Exception ex) {
-            response.addError("", ex.getMessage());
         }
 
         return response;
@@ -177,7 +198,7 @@ public class InventoryService implements IInventoryService {
      *{@inheritDoc}
      **/
     @Override
-    public ServiceResponse<MedicationItem> createMedicationInventory(int medicationId, int tripId){
+    public ServiceResponse<MedicationItem> createInventoryMedication(int medicationId, int tripId){
         ServiceResponse<MedicationItem> response = new ServiceResponse<>();
 
         IMedicationInventory medicationInventory;
@@ -228,19 +249,22 @@ public class InventoryService implements IInventoryService {
         try {
             //This should exist already, so no need to query for unique.
             medicationInventory = medicationRepository.retrieveMedicationInventoryByMedicationIdAndTripId(medicationId, tripId);
-
+            System.out.println(medicationInventory);
             //Soft-delete of the medication from the formulary, then update the backend to reflect the change.
             if (stateToSetTo == true) {
                 medicationInventory.setIsDeleted(DateTime.now());
             } else {
                 medicationInventory.setIsDeleted(null);
             }
+            System.out.println("A");
             medicationInventory = medicationRepository.saveMedicationInventory(medicationInventory);
+            System.out.println("B");
             medicationItem = itemModelMapper.createMedicationItem(medicationInventory.getMedication(),  medicationInventory.getQuantityCurrent(), medicationInventory.getQuantityInitial(), medicationInventory.getIsDeleted(), null, null);
             response.setResponseObject(medicationItem);
 
         } catch (Exception ex) {
             response.addError("", ex.getMessage());
+            System.out.println(ex.getMessage());
         }
 
         return response;

--- a/app/femr/business/services/system/InventoryService.java
+++ b/app/femr/business/services/system/InventoryService.java
@@ -200,7 +200,7 @@ public class InventoryService implements IInventoryService {
      *{@inheritDoc}
      **/
     @Override
-    public ServiceResponse<MedicationItem> createInventoryMedication(int medicationId, int tripId){
+    public ServiceResponse<MedicationItem> createMedicationInventory(int medicationId, int tripId){
         ServiceResponse<MedicationItem> response = new ServiceResponse<>();
 
         IMedicationInventory medicationInventory;

--- a/app/femr/business/services/system/InventoryService.java
+++ b/app/femr/business/services/system/InventoryService.java
@@ -188,6 +188,8 @@ public class InventoryService implements IInventoryService {
             medicationItem = itemModelMapper.createMedicationItem(medicationInventory.getMedication(),  medicationInventory.getQuantityCurrent(), medicationInventory.getQuantityInitial(), null, null, null);
 
             response.setResponseObject(medicationItem);
+        } catch (Exception ex) {
+            response.addError("", ex.getMessage());
         }
 
         return response;

--- a/app/femr/ui/controllers/admin/InventoryController.java
+++ b/app/femr/ui/controllers/admin/InventoryController.java
@@ -342,7 +342,7 @@ public class InventoryController extends Controller {
                         if(inventoryService.existsInventoryMedicationInTrip(medicationItemServiceResponse.getResponseObject().getId(),tripId).getResponseObject()){
                             createOrReAddInventoryResponse = inventoryService.reAddInventoryMedication(medicationItemServiceResponse.getResponseObject().getId(), tripId);
                         } else {
-                            createOrReAddInventoryResponse = inventoryService.createInventoryMedication(medicationItemServiceResponse.getResponseObject().getId(), tripId);
+                            createOrReAddInventoryResponse = inventoryService.createMedicationInventory(medicationItemServiceResponse.getResponseObject().getId(), tripId);
                         }
 
                         if (createOrReAddInventoryResponse.hasErrors()) {

--- a/app/femr/ui/controllers/admin/InventoryController.java
+++ b/app/femr/ui/controllers/admin/InventoryController.java
@@ -336,9 +336,15 @@ public class InventoryController extends Controller {
                         return internalServerError();
                     } else {
 
-                        //ServiceResponse<MedicationItem> setQuantityServiceResponse = inventoryService.setQuantityTotal(medicationItemServiceResponse.getResponseObject().getId(), tripId, 0);
-                        //ServiceResponse<MedicationItem> createOrReAddInventoryResponse = inventoryService.createNewInventoryMedicationOrReAddExisting(medicationItemServiceResponse.getResponseObject().getId(), tripId);
-                        ServiceResponse<MedicationItem> createOrReAddInventoryResponse = inventoryService.reAddInventoryMedication(medicationItemServiceResponse.getResponseObject().getId(), tripId);
+                        //Check to see if the medication has ever been added to the trip inventory.
+                        // If so, set it's soft deletion state to being 'undeleted'. Otherwise, create the inventory medication.
+                        ServiceResponse<MedicationItem> createOrReAddInventoryResponse = null;
+                        if(inventoryService.existsInventoryMedicationInTrip(medicationItemServiceResponse.getResponseObject().getId(),tripId).getResponseObject()){
+                            createOrReAddInventoryResponse = inventoryService.reAddInventoryMedication(medicationItemServiceResponse.getResponseObject().getId(), tripId);
+                        } else {
+                            createOrReAddInventoryResponse = inventoryService.createInventoryMedication(medicationItemServiceResponse.getResponseObject().getId(), tripId);
+                        }
+
                         if (createOrReAddInventoryResponse.hasErrors()) {
 
                             return internalServerError();


### PR DESCRIPTION
Bug occurred when a user tries to add a medication to the trip inventory that had never been added before (and thus cannot be readded because it has no soft-deletion state). Add new InventoryService function to check if a medication is related to the trip in question. Add logic in InventoryServiceController to use said medication and appropriately add new medication to trip inventory, or to just set the soft-delete state to 'undeleted'

https://teamfemr.atlassian.net/browse/FEMR-345
