### PR TITLE
Fix fEMR-346 and fEMR-260

### DIFF
--- a/app/femr/business/services/core/IConfigureService.java
+++ b/app/femr/business/services/core/IConfigureService.java
@@ -35,7 +35,8 @@ public interface IConfigureService {
     /**
      * Update more than one system setting.
      *
-     * @param systemSettings a list of active system setting names. system settings that don't exist in this list are assumed to be inactive
+     * @param systemSettings a list of active system setting names. system settings that don't exist in this list are assumed to be inactive.
+     *                       null if all system settings are to be set to "off"
      * @return a list of system settings after the update.
      */
     ServiceResponse<List<? extends ISystemSetting>> updateSystemSettings(List<String> systemSettings);

--- a/app/femr/business/services/system/ConfigureService.java
+++ b/app/femr/business/services/system/ConfigureService.java
@@ -60,19 +60,28 @@ public class ConfigureService implements IConfigureService {
         ServiceResponse<List<? extends ISystemSetting>> response = new ServiceResponse<>();
         List<? extends ISystemSetting> allSystemSettings = systemSettingRepository.findAll(SystemSetting.class);
 
+        System.out.println(systemSettings);
         try {
-            for (ISystemSetting ss : allSystemSettings) {
-                if (systemSettings.contains(ss.getName())) {
-                    ss.setActive(true);
-                    systemSettingRepository.update(ss);
-                } else {
+            if(systemSettings == null){
+                //If systemSettings is null, that means that all settings buttons were unchecked.
+                for (ISystemSetting ss: allSystemSettings){
                     ss.setActive(false);
                     systemSettingRepository.update(ss);
                 }
+            } else {
+                System.out.println(allSystemSettings.size());
+                for (ISystemSetting ss : allSystemSettings) {
+                    System.out.println(ss.getName());
+                    if (systemSettings.contains(ss.getName())) {
+                        ss.setActive(true);
+                        systemSettingRepository.update(ss);
+                    } else {
+                        ss.setActive(false);
+                        systemSettingRepository.update(ss);
+                    }
+                }
+                response.setResponseObject(allSystemSettings);
             }
-
-
-            response.setResponseObject(allSystemSettings);
         } catch (Exception ex) {
             response.addError("", ex.getMessage());
         }

--- a/app/femr/ui/controllers/admin/ConfigureController.java
+++ b/app/femr/ui/controllers/admin/ConfigureController.java
@@ -37,6 +37,7 @@ import play.mvc.Result;
 import play.mvc.Security;
 import femr.ui.views.html.admin.configure.manage;
 import java.util.List;
+import play.Logger;
 
 @Security.Authenticated(FEMRAuthenticated.class)
 @AllowedRoles({Roles.ADMINISTRATOR, Roles.SUPERUSER})
@@ -84,6 +85,7 @@ public class ConfigureController extends Controller {
 
         ServiceResponse<List<? extends ISystemSetting>> systemSettingsResponse = configureService.updateSystemSettings(viewModel.getSettings());
         if (systemSettingsResponse.hasErrors()) {
+            Logger.error("Failed to update System Configuration Settings", systemSettingsResponse.getErrors());
             throw new RuntimeException();
         }
 

--- a/app/femr/util/startup/MedicationDatabaseSeeder.java
+++ b/app/femr/util/startup/MedicationDatabaseSeeder.java
@@ -901,10 +901,10 @@ public class MedicationDatabaseSeeder {
         newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, "Principen", "caps"));
         conceptMedicationGenericStrengthsToAdd = new ArrayList<>();
         conceptMedicationGenericStrengthsToAdd.add(getConceptMedicationGenericStrength(conceptMedicationGenericStrengths, "aspirin", 325.0, "mg"));
-        newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, " ", "tabs"));
+        newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, "Bayer", "tabs"));
         conceptMedicationGenericStrengthsToAdd = new ArrayList<>();
         conceptMedicationGenericStrengthsToAdd.add(getConceptMedicationGenericStrength(conceptMedicationGenericStrengths, "aspirin", 81.0, "mg"));
-        newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, " ", "tabs"));
+        newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, "Bayer", "tabs"));
         conceptMedicationGenericStrengthsToAdd = new ArrayList<>();
         conceptMedicationGenericStrengthsToAdd.add(getConceptMedicationGenericStrength(conceptMedicationGenericStrengths, "atenolol", 50.0, "mg"));
         newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, "Tenormin", "tabs"));
@@ -976,13 +976,13 @@ public class MedicationDatabaseSeeder {
         newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, "Colace", "tabs"));
         conceptMedicationGenericStrengthsToAdd = new ArrayList<>();
         conceptMedicationGenericStrengthsToAdd.add(getConceptMedicationGenericStrength(conceptMedicationGenericStrengths, "doxycycline", 100.0, "mg"));
-        newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, " ", "caps"));
+        newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, "Vibramycin", "caps"));
         conceptMedicationGenericStrengthsToAdd = new ArrayList<>();
         conceptMedicationGenericStrengthsToAdd.add(getConceptMedicationGenericStrength(conceptMedicationGenericStrengths, "doxycycline", 150.0, "mg"));
         newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, "Adoxa", "caps"));
         conceptMedicationGenericStrengthsToAdd = new ArrayList<>();
         conceptMedicationGenericStrengthsToAdd.add(getConceptMedicationGenericStrength(conceptMedicationGenericStrengths, "doxycycline", 75.0, "mg"));
-        newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, " ", "caps"));
+        newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, "Vibramycin", "caps"));
         conceptMedicationGenericStrengthsToAdd = new ArrayList<>();
         conceptMedicationGenericStrengthsToAdd.add(getConceptMedicationGenericStrength(conceptMedicationGenericStrengths, "econazole", 85.0, "mg"));
         newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, "Spectazole", "crm"));
@@ -997,7 +997,7 @@ public class MedicationDatabaseSeeder {
         newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, "Diflucan", "tabs"));
         conceptMedicationGenericStrengthsToAdd = new ArrayList<>();
         conceptMedicationGenericStrengthsToAdd.add(getConceptMedicationGenericStrength(conceptMedicationGenericStrengths, "folic acid", 1.0, "mg"));
-        newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, " ", "tabs"));
+        newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, "Folvite", "tabs"));
         conceptMedicationGenericStrengthsToAdd = new ArrayList<>();
         conceptMedicationGenericStrengthsToAdd.add(getConceptMedicationGenericStrength(conceptMedicationGenericStrengths, "glipizide", 10.0, "mg"));
         newConceptMedications.add(addConceptMedication(conceptMedications, conceptMedicationFormMap, conceptMedicationGenericStrengthsToAdd, "Glucotrol", "tabs"));


### PR DESCRIPTION
fEMR-346: Provide brand names for medications where brand name was given as " ". Brand names that were whitespace would eventually cause a NullPointerException in MecationService.createMedication caused by from null being returned from MedicationRepository.createNewMedication (see https://github.com/FEMR/femr/blob/dddc749359d94786b923a08e46861500c46459cf/app/femr/data/daos/system/MedicationRepository.java#L55-L60), and then causing a NullPointerException.

fEMR-260: When all settings are unchecked, a null list of system settings is passed to ConfigureService.updateSystemSettings; Add logic in that method to account for that and set all settings to be inactive. Add logger message in ConfigureController for the (hopefully rare) case where config updates fail.

https://teamfemr.atlassian.net/browse/FEMR-346
https://teamfemr.atlassian.net/browse/FEMR-260