### PR TITLE
Change log location on femr systems

### DIFF
--- a/conf/prod-logger.xml
+++ b/conf/prod-logger.xml
@@ -1,6 +1,6 @@
 <configuration>
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${application.home:-.}/logs/application.log</file>
+        <file>${user.home}/logs/application.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- Daily rollover with compression -->
             <fileNamePattern>application-log-%d{yyyy-MM-dd}.gz</fileNamePattern>


### PR DESCRIPTION
Change to to '~/logs/application.log'. Done to standardize log file paths across femrservers to allow for automated retrieval of logs using bash script on central.