### PR TITLE
Fix recognition of when rssh has failed

### DIFF
--- a/app/femr/util/InternetConnnection/InternetConnectionUtil.java
+++ b/app/femr/util/InternetConnnection/InternetConnectionUtil.java
@@ -231,7 +231,7 @@ public final class InternetConnectionUtil {
     }
 
     public static Boolean maintainRsshSession() {
-        if (rsshSession != null && !rsshSession.isConnected()) {
+        if (rsshSession == null || !rsshSession.isConnected()) {
             Logger.info("The SSH session has either not been established or it has been broken");
             rsshSession = buildSSHSession();
         } else {


### PR DESCRIPTION
When rssh fails, the build function returns null. Properly check for null, and rebuild the rssh if the ssh session is not null but is also not connected