### PR TITLE
Updated dependency for mysql-connector-java to 5.1.49.

### DIFF
--- a/Build.sbt
+++ b/Build.sbt
@@ -16,7 +16,7 @@ val appDependencies = Seq(
   evolutions,
   jodaForms,
   guice,
-  "mysql" % "mysql-connector-java" % "5.1.41",
+  "mysql" % "mysql-connector-java" % "5.1.49",
   "org.mindrot" % "jbcrypt" % "0.3m",
   "org.apache.commons" % "commons-collections4" % "4.0",
   "org.apache.commons" % "commons-text" % "1.3",


### PR DESCRIPTION
The prior version of mysql-connector-java was outdated and needed to be updated to support query_cache_size.