### PR TITLE
Tremr: Add erase all button and save only lines

### DIFF
--- a/app/femr/ui/views/trauma/index.scala.html
+++ b/app/femr/ui/views/trauma/index.scala.html
@@ -359,8 +359,10 @@
                         </label>
                         <button id="eraseAll">Erase All</button>
                         <button id="save">Save Image</button>
-
-
+                        <div>
+                            Brush Color:
+                            <input type="color" id="brushColor" name="brushColor" value="#df4b26">
+                        </div>
                     </div>
                     <div id="container"></div>
                     <script type="text/javascript" src="@assets.path("js/trauma/konvaDraw.js")"></script>

--- a/app/femr/ui/views/trauma/index.scala.html
+++ b/app/femr/ui/views/trauma/index.scala.html
@@ -357,7 +357,9 @@
                             <input type="radio" id="drawCheckbox" value="eraser" name="drawCheckbox" onclick="onlyOneTool(this)" class="filled">
                             Eraser
                         </label>
+                        <button id="eraseAll">Erase All</button>
                         <button id="save">Save Image</button>
+
 
                     </div>
                     <div id="container"></div>

--- a/public/js/trauma/konvaDraw.js
+++ b/public/js/trauma/konvaDraw.js
@@ -57,7 +57,7 @@ stage.on('mousedown touchstart', function (e) {
     isPaint = true;
     var pos = stage.getPointerPosition();
     lastLine = new Konva.Line({
-        stroke: '#df4b26',
+        stroke: document.getElementById("brushColor").value,
         strokeWidth: 5,
         globalCompositeOperation:
             mode === 'brush' ? 'source-over' : 'destination-out',

--- a/public/js/trauma/trauma.js
+++ b/public/js/trauma/trauma.js
@@ -23,7 +23,7 @@ function downloadURI(uri, name) {
 document.getElementById('save').addEventListener(
     'click',
     function () {
-        var dataURL = stage.toDataURL();
+        var dataURL = layer.toDataURL();
         downloadURI(dataURL, 'patient.png');
     },
     false

--- a/public/js/trauma/trauma.js
+++ b/public/js/trauma/trauma.js
@@ -29,6 +29,14 @@ document.getElementById('save').addEventListener(
     false
 );
 
+document.getElementById('eraseAll').addEventListener(
+    'click',
+    function () {
+        layer.destroyChildren();
+    },
+    false
+);
+
 $('#femaleBtn').change(function () {
     $('#weeksPregnant').attr('disabled', false);
     changeBackground("femaleBtn");


### PR DESCRIPTION
Added 2 new features and fixed one existing behavior for the drawing component:
1. Choosing brush color.
2. Erase all lines button.
3. Saving only lines (without the body image).

|erase all button and brush color option| saved file example |
|-|-|
|<img width="524" alt="Screen Shot 2022-04-14 at 12 48 29 AM" src="https://user-images.githubusercontent.com/23184246/163339573-07de8f9d-36e8-4a40-81ce-8489c75d1b0b.png">|![patient (6)](https://user-images.githubusercontent.com/23184246/163339591-5a53873b-05a7-4f7d-afc7-11fd87995765.png)|