### PR TITLE
Tremr: Add docker install for Mac M1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 services:
 
   db:
+    platform: linux/x86_64
     image: mysql:5.7
     restart: always
     environment:


### PR DESCRIPTION
Docker install did not work on Mac M1. This fixes the issue with M1.

Reference: https://stackoverflow.com/questions/65456814/docker-apple-silicon-m1-preview-mysql-no-matching-manifest-for-linux-arm64-v8