### PR TITLE
Add speedtest scripts to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ ENV BUILD_DATE=$BUILD_DATE
 COPY --from=builder /usr/src/app/target/universal/femr-* /opt/bin/femr
 
 #include speedtest scripts into final image
-COPY --from=builder /usr/speedtest /usr/src/speedtest
+COPY --from=builder /usr/src/speedtest /usr/src/speedtest
 
 #open port 9000 for connections
 EXPOSE 9000

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,9 @@ ENV BUILD_DATE=$BUILD_DATE
 
 COPY --from=builder /usr/src/app/target/universal/femr-* /opt/bin/femr
 
+#include speedtest scripts into final image
+COPY --from=builder /usr/speedtest /usr/src/speedtest
+
 #open port 9000 for connections
 EXPOSE 9000
 


### PR DESCRIPTION
While building the docker image, the Dockerfile doesn't include ./speedtest scripts into the final app image. Not sure how the current builds were handling speedtest functions if they were working. 

Discovered while working on FEMR/windows-installer. The ./speedtest folder from FEMR/femr is required to be manually copied into the FEMR/windows-installer to generate installers and ./speedtest is part of femr app logic. It would be more organized to directly have the speedtest scripts be a part of the image.

Currently, worked around but would like a merge asap to keep windows-installer organized and update femr image on docker hub through the Github Actions. 