### PR TITLE
Quick workflow patch

### DIFF
--- a/.github/workflows/installer-dispatch.yml
+++ b/.github/workflows/installer-dispatch.yml
@@ -69,7 +69,7 @@ jobs:
           DATE: ${{ env.DATE }}
         with:
           context: .
-          platforms: linux/amd64, linux/arm64 #Platforms to build image for.
+          platforms: linux/amd64 #Platforms to build image for.
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |


### PR DESCRIPTION
Removed arm64 build temporarily, will require future attention or new base docker image replacement in Dockerfile. 

eclipse-temurin:8-jre-alpine-3.23 does not support arm64 architecture.