### PR TITLE
Various Bug Fixes

### DIFF
--- a/app/femr/business/services/system/MissionTripService.java
+++ b/app/femr/business/services/system/MissionTripService.java
@@ -35,6 +35,7 @@ import femr.data.models.mysql.*;
 import femr.util.stringhelpers.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -353,7 +354,18 @@ public class MissionTripService implements IMissionTripService {
                 tripItem.getTripEndDate() == null) {
             response.addError("", "you're missing required fields, try again");
         } else {
-            try {
+            Calendar calToday = Calendar.getInstance();
+            calToday.set(Calendar.HOUR_OF_DAY, 0);
+            calToday.set(Calendar.MINUTE, 0);
+            calToday.set(Calendar.SECOND, 0);
+            calToday.set(Calendar.MILLISECOND, 0);
+            Date today = calToday.getTime();
+
+            if (tripItem.getTripStartDate().before(today)) {
+                response.addError("", "start date cannot be in the past");
+            } else if (tripItem.getTripEndDate().before(tripItem.getTripStartDate())) {
+                response.addError("", "end date cannot be before start date");
+            } else try {
 
 
                 ExpressionList<MissionTeam> missionTeamExpressionList = QueryProvider.getMissionTeamQuery()

--- a/app/femr/data/models/mysql/ChiefComplaint.java
+++ b/app/femr/data/models/mysql/ChiefComplaint.java
@@ -29,7 +29,7 @@ public class ChiefComplaint implements IChiefComplaint {
     @Id
     @Column(name = "id", unique = true, nullable = false)
     private int id;
-    @Column(name = "value")
+    @Column(name = "value", columnDefinition = "TEXT")
     private String value;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "patient_encounter_id")

--- a/app/femr/ui/controllers/MedicalController.java
+++ b/app/femr/ui/controllers/MedicalController.java
@@ -61,7 +61,8 @@ public class MedicalController extends Controller {
                              IPhotoService photoService,
                              ISessionService sessionService,
                              ISearchService searchService,
-                             IVitalService vitalService) {
+                             IVitalService vitalService,
+                             FieldHelper fieldHelper) {
 
         this.assetsFinder = assetsFinder;
         this.formFactory = formFactory;
@@ -72,7 +73,7 @@ public class MedicalController extends Controller {
         this.medicationService = medicationService;
         this.photoService = photoService;
         this.vitalService = vitalService;
-        this.fieldHelper = new FieldHelper();
+        this.fieldHelper = fieldHelper;
     }
 
     public Result indexGet() {

--- a/app/femr/ui/controllers/helpers/FieldHelper.java
+++ b/app/femr/ui/controllers/helpers/FieldHelper.java
@@ -6,11 +6,13 @@ import femr.common.models.TabItem;
 import femr.util.DataStructure.Mapping.TabFieldMultiMap;
 import femr.util.stringhelpers.StringUtils;
 
+import javax.inject.Singleton;
 import java.util.*;
 
 /**
  * Helps logically arrange fields for the views after retrieving data from the service
  */
+@Singleton
 public class FieldHelper {
 
     //READ THE METHOD NAME LOL

--- a/app/femr/ui/models/admin/users/CreateViewModel.java
+++ b/app/femr/ui/models/admin/users/CreateViewModel.java
@@ -50,25 +50,25 @@ public class CreateViewModel implements Constraints.Validatable<List<ValidationE
     Pattern PassReqs = Pattern.compile("(?=.*\\d)(?=.*[A-Z])(?=.*[a-z])(?=.*[^a-zA-Z0-9]).{8,}");
 
         if (StringUtils.isNullOrWhiteSpace(firstName))
-            errors.add(new ValidationError("firstName", "first name is a required field"));
+            errors.add(new ValidationError("firstName", "First name is a required field."));
         if (StringUtils.isNullOrWhiteSpace(email))
-            errors.add(new ValidationError("email", "email is a required field"));
+            errors.add(new ValidationError("email", "Email is a required field."));
         if (StringUtils.isNullOrWhiteSpace(password))
-            errors.add(new ValidationError("password", "password is a required field"));
+            errors.add(new ValidationError("password", "Password is a required field."));
         // added for FEMR-159
 
         if (StringUtils.isNotNullOrWhiteSpace(password) && !PassReqs.matcher(password).find()) {
-            errors.add(new ValidationError("password", "password must have at least one uppercase, one lowercase, one digit, one symbol, and be at least 8 characters long."));
+            errors.add(new ValidationError("password", "Password must have at least one uppercase, one lowercase, one digit, one symbol, and be at least 8 characters long."));
         }
 
-        if (!password.equals(passwordVerify)) {
-            errors.add(new ValidationError("password", "passwords do not match"));
+        if (StringUtils.isNotNullOrWhiteSpace(password) && !password.equals(passwordVerify)) {
+            errors.add(new ValidationError("passwordVerify", "Passwords do not match."));
          }
         if (roles == null || roles.size() < 1)
-            errors.add(new ValidationError("roles", "a user needs at least one role"));
+            errors.add(new ValidationError("roles", "A user needs at least one role."));
 
         if (StringUtils.isNotNullOrWhiteSpace(password) && password.length() < 8)
-            errors.add(new ValidationError("password", "The password must contain at least 8 characters"));
+            errors.add(new ValidationError("password", "Password must contain at least 8 characters."));
 
         return errors.isEmpty() ? null : errors;
     }

--- a/app/femr/ui/views/admin/users/create.scala.html
+++ b/app/femr/ui/views/admin/users/create.scala.html
@@ -46,8 +46,14 @@
         </div>
 
         @helper.form(action = UsersController.createPost(), 'name -> "createForm") {
+            <div class="admin-form__alert" id="createUserFormSummary" role="alert" @if(!form.hasErrors) { style="display:none;" }>
+                @if(form.hasErrors) {
+                    Please fix the highlighted fields and try again.
+                }
+            </div>
+
             <div class="admin-form admin-form--stacked">
-                <div class="admin-form__field">
+                <div class="admin-form__field @if(!form("email").errors.isEmpty) {admin-form__field--invalid}">
                     <label for="email">Email address <span class="admin-required" aria-hidden="true">*</span></label>
                     @defining(form("email").getValue.orElse("")) { value =>
                         <input id="email" name="email" type="email" value="@value" placeholder="name@@example.com" />
@@ -60,21 +66,29 @@
                 </div>
 
                 <div class="admin-form__row">
-                    <div class="admin-form__field">
+                    <div class="admin-form__field @if(!form("password").errors.isEmpty) {admin-form__field--invalid}">
                         <label for="password">Password <span class="admin-required" aria-hidden="true">*</span></label>
                         <input id="password" name="password" type="password" placeholder="Set a secure password" />
                         <p class="admin-form__hint">Use at least 8 characters with at least 1 uppercase letter, 1 lowercase letter, 1 number, and 1 symbol.</p>
-                        <span class="errors"></span>
+                        <span class="errors">
+                            @if(!form("password").errors.isEmpty) {
+                                @form("password").errors.get(0).message
+                            }
+                        </span>
                     </div>
-                    <div class="admin-form__field">
+                    <div class="admin-form__field @if(!form("passwordVerify").errors.isEmpty) {admin-form__field--invalid}">
                         <label for="passwordVerify">Verify password</label>
                         <input id="passwordVerify" name="passwordVerify" type="password" placeholder="Re-enter password" />
-                        <span class="errors"></span>
+                        <span class="errors">
+                            @if(!form("passwordVerify").errors.isEmpty) {
+                                @form("passwordVerify").errors.get(0).message
+                            }
+                        </span>
                     </div>
                 </div>
 
                 <div class="admin-form__row">
-                    <div class="admin-form__field">
+                    <div class="admin-form__field @if(!form("firstName").errors.isEmpty) {admin-form__field--invalid}">
                         <label for="firstName">First name <span class="admin-required" aria-hidden="true">*</span></label>
                         @defining(form("firstName").getValue.orElse("")) { value =>
                             <input id="firstName" name="firstName" type="text" value="@value" placeholder="First name" />
@@ -103,7 +117,7 @@
                 </div>
 
                 <div class="admin-form__field">
-                    <div id="roleWrap" class="admin-form__fieldset">
+                    <div id="roleWrap" class="admin-form__fieldset @if(!form("roles").errors.isEmpty) {admin-form__field--invalid}">
                         <div class="admin-form__legend">
                             <span>Roles</span>
                             <span class="admin-required" aria-hidden="true">*</span>

--- a/app/femr/ui/views/manager/index.scala.html
+++ b/app/femr/ui/views/manager/index.scala.html
@@ -115,7 +115,7 @@
                                             .filter(_.nonEmpty)
                                             .getOrElse("—")
                                     ) { chiefComplaint =>
-                                        <td>@chiefComplaint</td>
+                                        <td class="manager-table__chief-complaint">@chiefComplaint</td>
                                     }
                                     @defining(Option(encounterItem.getTriageDateOfVisit).map(_.trim).filter(_.nonEmpty).getOrElse("—")) { triageTime =>
                                         <td>@triageTime</td>

--- a/app/femr/ui/views/triage/index.scala.html
+++ b/app/femr/ui/views/triage/index.scala.html
@@ -533,7 +533,8 @@
                                 </label>
                             </div>
                             <input type="text" class="hidden" name="chiefComplaintsJSON"/>
-                            <textarea class="fTextArea femr-textarea" id="chiefComplaint" name="chiefComplaint"></textarea>
+                            <textarea class="fTextArea femr-textarea" id="chiefComplaint" name="chiefComplaint" maxlength="2000"></textarea>
+                            <small id="chiefComplaintCharCount" class="femr-char-count">0 / 2000</small>
                             @if(viewModel.getSettings.isMultipleChiefComplaint) {
                                 <ol id="chiefComplaintList" class="femr-chief__list"></ol>
                             }

--- a/public/css/admin/admin_redesign.css
+++ b/public/css/admin/admin_redesign.css
@@ -1161,6 +1161,45 @@
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.admin-form__field--invalid input[type="text"],
+.admin-form__field--invalid input[type="number"],
+.admin-form__field--invalid input[type="date"],
+.admin-form__field--invalid input[type="email"],
+.admin-form__field--invalid input[type="password"],
+.admin-form__field--invalid select,
+.admin-form__field--invalid textarea {
+    border-color: #dc2626;
+    box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.14);
+}
+
+.admin-form__field--invalid label,
+.admin-form__field--invalid .admin-form__legend,
+.admin-form__field--invalid .admin-checkbox span {
+    color: #dc2626;
+}
+
+.admin-form__field--invalid .admin-checkbox-grid {
+    border: 1px solid rgba(220, 38, 38, 0.35);
+    border-radius: 12px;
+    padding: 12px;
+    background: rgba(220, 38, 38, 0.04);
+}
+
+.admin-form__field--invalid .errors {
+    color: #dc2626;
+    font-weight: 600;
+}
+
+.admin-form__alert {
+    border: 1px solid rgba(220, 38, 38, 0.35);
+    background: rgba(220, 38, 38, 0.08);
+    color: #991b1b;
+    padding: 12px 14px;
+    border-radius: 12px;
+    margin-bottom: 16px;
+    font-weight: 600;
+}
+
 .admin-guidelines {
     margin: 0 0 16px 18px;
     padding: 0;

--- a/public/css/history.css
+++ b/public/css/history.css
@@ -400,6 +400,12 @@
     text-align: left;
 }
 
+.chiefComplaint {
+    white-space: normal;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
 .encbtns:hover {
     background: #f9fafb;
 }

--- a/public/css/manager/manager.css
+++ b/public/css/manager/manager.css
@@ -103,6 +103,12 @@
     color: var(--femr-color-text, #1c1917);
 }
 
+.manager-table__chief-complaint {
+    max-width: 240px;
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+
 .manager-table__link {
     color: var(--femr-color-primary, #2563eb);
     font-weight: 600;

--- a/public/css/triage_redesign.css
+++ b/public/css/triage_redesign.css
@@ -620,6 +620,18 @@
     gap: 8px;
 }
 
+.femr-char-count {
+    display: block;
+    text-align: right;
+    font-size: 0.75rem;
+    color: var(--femr-color-text-secondary, #6b7280);
+}
+
+.femr-char-count--limit {
+    color: var(--femr-color-primary, #dc2626);
+    font-weight: 600;
+}
+
 .femr-diabetes-prompt {
     padding: 24px;
     border-radius: 16px;

--- a/public/js/admin/users.js
+++ b/public/js/admin/users.js
@@ -67,24 +67,47 @@ var createAndEditUsers = {
     elements: {
         firstName: $("#firstName"),
         email: $("#email"),
-        roles: $("#roleWrap")
+        roles: $("#roleWrap"),
+        summary: $("#createUserFormSummary")
+    },
+    setFieldInvalid: function ($field, message) {
+        $field.addClass("admin-form__field--invalid");
+        $field.find(".errors").first().text(message);
+    },
+    clearFieldInvalid: function ($field) {
+        $field.removeClass("admin-form__field--invalid");
+        $field.find(".errors").first().text("");
+    },
+    setSummary: function (message) {
+        if (createAndEditUsers.elements.summary.length) {
+            createAndEditUsers.elements.summary.text(message).show();
+        }
+    },
+    clearSummary: function () {
+        if (createAndEditUsers.elements.summary.length) {
+            createAndEditUsers.elements.summary.text("").hide();
+        }
     },
     validateElements: function () {
         var pass = true;
+        createAndEditUsers.clearSummary();
+        createAndEditUsers.clearFieldInvalid(createAndEditUsers.elements.email.closest(".admin-form__field"));
+        createAndEditUsers.clearFieldInvalid(createAndEditUsers.elements.firstName.closest(".admin-form__field"));
+
         if ($.trim(document.forms["createForm"]["email"].value) === "") {
-            createAndEditUsers.elements.email.next(".errors").text("email is a required field");
+            createAndEditUsers.setFieldInvalid(createAndEditUsers.elements.email.closest(".admin-form__field"), "Email is a required field.");
             pass = false;
-        } else {
-            createAndEditUsers.elements.email.next(".errors").text("");
         }
 
         if ($.trim(document.forms["createForm"]["firstName"].value) === "") {
-            createAndEditUsers.elements.firstName.next(".errors").text("first name is a required field");
+            createAndEditUsers.setFieldInvalid(createAndEditUsers.elements.firstName.closest(".admin-form__field"), "First name is a required field.");
             pass = false;
-        } else {
-            createAndEditUsers.elements.firstName.next(".errors").text("");
         }
         //check roles
+
+        if (pass === false) {
+            createAndEditUsers.setSummary("Please fix the highlighted fields and try again.");
+        }
 
         return pass;
     }
@@ -92,17 +115,31 @@ var createAndEditUsers = {
 
 var createUsers = {
     elements: {
-        password: $("#password")
+        password: $("#password"),
+        passwordVerify: $("#passwordVerify")
+    },
+    setFieldInvalid: function ($field, message) {
+        $field.addClass("admin-form__field--invalid");
+        $field.find(".errors").first().text(message);
+    },
+    clearFieldInvalid: function ($field) {
+        $field.removeClass("admin-form__field--invalid");
+        $field.find(".errors").first().text("");
     },
     validateRolesAndPassword: function () {
         var pass = true;
         // Adding password constraint!
         var passwordErrors = "";
         var password = $.trim(document.forms["createForm"]["password"].value);
-        createUsers.elements.password.next(".errors").text(passwordVerify);
+        var passwordVerify = $.trim(document.forms["createForm"]["passwordVerify"].value);
+        var $passwordField = createUsers.elements.password.closest(".admin-form__field");
+        var $passwordVerifyField = createUsers.elements.passwordVerify.closest(".admin-form__field");
+
+        createUsers.clearFieldInvalid($passwordField);
+        createUsers.clearFieldInvalid($passwordVerifyField);
 
         if (password  === "") {
-            passwordErrors = "please assign this user a password";
+            passwordErrors = "Please assign this user a password.";
             pass = false;
         }
         else{
@@ -115,19 +152,27 @@ var createUsers = {
             }
         }
 
+        if (password !== "" && password !== passwordVerify) {
+            pass = false;
+            createUsers.setFieldInvalid($passwordVerifyField, "Passwords do not match.");
+            createUsers.setFieldInvalid($passwordField, "Passwords do not match.");
+        }
+
         if(pass === false)
         {
             if (passwordErrors !== "")
-                createUsers.elements.password.next (".errors").text(passwordErrors);
+                createUsers.setFieldInvalid($passwordField, passwordErrors);
             else
-                createUsers.elements.password.next(".errors").text("password must have at least one uppercase, one lowercase, one digit, one symbol, and be at least 8 characters long.");
+                createUsers.setFieldInvalid($passwordField, "Password must have at least one uppercase, one lowercase, one digit, one symbol, and be at least 8 characters long.");
         }
         else{
-            createUsers.elements.password.next(".errors").text("");
+            createUsers.clearFieldInvalid($passwordField);
         }
 
         //validate roles
         var isARoleChecked = false;
+        var $roleField = createAndEditUsers.elements.roles.closest(".admin-form__field");
+        createAndEditUsers.clearFieldInvalid($roleField);
         $.each(document.forms["createForm"].elements["roles[]"], function () {
             if ($(this).is(':checked')) {
                 isARoleChecked = true;
@@ -138,9 +183,9 @@ var createUsers = {
         }
         if (isARoleChecked === false) {
             pass = false;
-            createAndEditUsers.elements.roles.find(".errors").text("select at least one role");
+            createAndEditUsers.setFieldInvalid($roleField, "Select at least one role.");
         } else {
-            createAndEditUsers.elements.roles.find(".errors").text("");
+            createAndEditUsers.clearFieldInvalid($roleField);
         }
         return pass;
     },
@@ -148,6 +193,9 @@ var createUsers = {
         $('#addUserSubmitBtn').click(function () {
             var roleAndPasswordValidation = createUsers.validateRolesAndPassword();
             var elementValidation = createAndEditUsers.validateElements();
+            if (!roleAndPasswordValidation || !elementValidation) {
+                createAndEditUsers.setSummary("Please fix the highlighted fields and try again.");
+            }
             return roleAndPasswordValidation && elementValidation;
         });
     },

--- a/public/js/superuser/superuser.js
+++ b/public/js/superuser/superuser.js
@@ -6,6 +6,17 @@ $(document).ready(function(){
         $("[name='newTripCountry']").val($(this).find(':selected').attr('country-name'));
     });
 
+    var today = new Date().toISOString().split('T')[0];
+    $('#newTripStartDate').attr('min', today);
+
+    $('#newTripStartDate').change(function() {
+        var startDate = $(this).val();
+        $('#newTripEndDate').attr('min', startDate);
+        if ($('#newTripEndDate').val() && $('#newTripEndDate').val() < startDate) {
+            $('#newTripEndDate').val('');
+        }
+    });
+
     if ($.fn.DataTable) {
         if ($('#tripTable').length > 0)
             $('#tripTable').DataTable();

--- a/public/js/triage/triage.js
+++ b/public/js/triage/triage.js
@@ -966,5 +966,16 @@ $("#heightInches").change(function(){
     $(triageFields.patientVitals.heightInches).val(heightInches || "");
 });
 
+$('#chiefComplaint').on('input', function () {
+    var maxLen = parseInt($(this).attr('maxlength'), 10);
+    var currentLen = $(this).val().length;
+    var counter = $('#chiefComplaintCharCount');
+    counter.text(currentLen + ' / ' + maxLen);
+    if (currentLen >= maxLen) {
+        counter.addClass('femr-char-count--limit');
+    } else {
+        counter.removeClass('femr-char-count--limit');
+    }
+});
 
 

--- a/test/unit/app/femr/business/services/TranslationServiceTest.java
+++ b/test/unit/app/femr/business/services/TranslationServiceTest.java
@@ -3,6 +3,7 @@ package unit.app.femr.business.services;
 import controllers.AssetsFinder;
 import femr.business.services.core.*;
 import femr.ui.controllers.MedicalController;
+import femr.ui.controllers.helpers.FieldHelper;
 import femr.util.translation.TranslationServer;
 import org.junit.Assert;
 import org.junit.Before;
@@ -47,7 +48,8 @@ public class TranslationServiceTest {
                 photoService,
                 sessionService,
                 searchService,
-                vitalService);
+                vitalService,
+                new FieldHelper());
     }
 
     //MedicalController Tests


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the mission trip creation process, chief complaint handling, and UI enhancements for better user experience and data integrity. The most significant changes include stricter date validation for mission trips, enhanced chief complaint input handling, dependency injection improvements, and related UI/UX updates.

**Mission Trip Date Validation:**

* Added backend validation to ensure the trip start date is not in the past and the end date is not before the start date in `MissionTripService.java`.
* Updated the frontend to restrict selectable trip start and end dates using min attributes and dynamic validation in `superuser.js`.

**Chief Complaint Input Improvements:**

* Set a `maxlength` of 2000 characters for the chief complaint textarea, added a live character counter, and styled the counter for limit warnings in `triage/index.scala.html`, `triage.js`, and `triage_redesign.css`. [[1]](diffhunk://#diff-96ac8c516310254bfa9e649a549e62ddbaf4598956ab370a55989f0b4242e247L536-R537) [[2]](diffhunk://#diff-e2985f580341ae8eb8062185a54bb25b4b308d1b26f4ccfaf18e67d775776930R969-R979) [[3]](diffhunk://#diff-47906f30de13a7b686a4d843915d3374d6edae56155bf31cfcf7c80c6efc60bdR623-R634)
* Updated the database column for chief complaint value to use `TEXT` type to support longer inputs in `ChiefComplaint.java`.
* Improved table display for chief complaints by adding a max-width and wrapping styles in `manager/index.scala.html` and `manager.css`. [[1]](diffhunk://#diff-41bd48858a87b36597e8aa1c1a11e7c73de5e26450a85c1de142a3161716188fL118-R118) [[2]](diffhunk://#diff-78445d5459cf0b19ced52f22679b4b52c3859536db058d14b62472d0e741e188R106-R111)
* Added extra wrapping styles for chief complaint display in `history.css`.

**Dependency Injection and Test Updates:**

* Modified `MedicalController` to accept `FieldHelper` as a constructor parameter for better dependency injection, and updated related test setup and annotations for `FieldHelper`. [[1]](diffhunk://#diff-5c7bea9e66dca72b4f9a74dded8a45380a35630dfcbdd9e750affe2bf06abb0dL64-R65) [[2]](diffhunk://#diff-5c7bea9e66dca72b4f9a74dded8a45380a35630dfcbdd9e750affe2bf06abb0dL75-R76) [[3]](diffhunk://#diff-8dde3773e1071fade17dfb2fd5d3de683dbc259c9bf6cbf6eb4801d63be18169R9-R15) [[4]](diffhunk://#diff-cc19d4bbc82604e04394fd90823220ae2b148640358367f0b85ae6dbf75d19f7R6) [[5]](diffhunk://#diff-cc19d4bbc82604e04394fd90823220ae2b148640358367f0b85ae6dbf75d19f7L50-R52)