### PR TITLE
Bug fixing

### DIFF
--- a/app/femr/business/services/system/MissionTripService.java
+++ b/app/femr/business/services/system/MissionTripService.java
@@ -35,6 +35,7 @@ import femr.data.models.mysql.*;
 import femr.util.stringhelpers.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -353,7 +354,18 @@ public class MissionTripService implements IMissionTripService {
                 tripItem.getTripEndDate() == null) {
             response.addError("", "you're missing required fields, try again");
         } else {
-            try {
+            Calendar calToday = Calendar.getInstance();
+            calToday.set(Calendar.HOUR_OF_DAY, 0);
+            calToday.set(Calendar.MINUTE, 0);
+            calToday.set(Calendar.SECOND, 0);
+            calToday.set(Calendar.MILLISECOND, 0);
+            Date today = calToday.getTime();
+
+            if (tripItem.getTripStartDate().before(today)) {
+                response.addError("", "start date cannot be in the past");
+            } else if (tripItem.getTripEndDate().before(tripItem.getTripStartDate())) {
+                response.addError("", "end date cannot be before start date");
+            } else try {
 
 
                 ExpressionList<MissionTeam> missionTeamExpressionList = QueryProvider.getMissionTeamQuery()

--- a/app/femr/data/models/mysql/ChiefComplaint.java
+++ b/app/femr/data/models/mysql/ChiefComplaint.java
@@ -29,7 +29,7 @@ public class ChiefComplaint implements IChiefComplaint {
     @Id
     @Column(name = "id", unique = true, nullable = false)
     private int id;
-    @Column(name = "value")
+    @Column(name = "value", columnDefinition = "TEXT")
     private String value;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "patient_encounter_id")

--- a/app/femr/ui/controllers/MedicalController.java
+++ b/app/femr/ui/controllers/MedicalController.java
@@ -61,7 +61,8 @@ public class MedicalController extends Controller {
                              IPhotoService photoService,
                              ISessionService sessionService,
                              ISearchService searchService,
-                             IVitalService vitalService) {
+                             IVitalService vitalService,
+                             FieldHelper fieldHelper) {
 
         this.assetsFinder = assetsFinder;
         this.formFactory = formFactory;
@@ -72,7 +73,7 @@ public class MedicalController extends Controller {
         this.medicationService = medicationService;
         this.photoService = photoService;
         this.vitalService = vitalService;
-        this.fieldHelper = new FieldHelper();
+        this.fieldHelper = fieldHelper;
     }
 
     public Result indexGet() {

--- a/app/femr/ui/controllers/helpers/FieldHelper.java
+++ b/app/femr/ui/controllers/helpers/FieldHelper.java
@@ -6,11 +6,13 @@ import femr.common.models.TabItem;
 import femr.util.DataStructure.Mapping.TabFieldMultiMap;
 import femr.util.stringhelpers.StringUtils;
 
+import javax.inject.Singleton;
 import java.util.*;
 
 /**
  * Helps logically arrange fields for the views after retrieving data from the service
  */
+@Singleton
 public class FieldHelper {
 
     //READ THE METHOD NAME LOL

--- a/app/femr/ui/views/manager/index.scala.html
+++ b/app/femr/ui/views/manager/index.scala.html
@@ -115,7 +115,7 @@
                                             .filter(_.nonEmpty)
                                             .getOrElse("—")
                                     ) { chiefComplaint =>
-                                        <td>@chiefComplaint</td>
+                                        <td class="manager-table__chief-complaint">@chiefComplaint</td>
                                     }
                                     @defining(Option(encounterItem.getTriageDateOfVisit).map(_.trim).filter(_.nonEmpty).getOrElse("—")) { triageTime =>
                                         <td>@triageTime</td>

--- a/app/femr/ui/views/triage/index.scala.html
+++ b/app/femr/ui/views/triage/index.scala.html
@@ -533,7 +533,8 @@
                                 </label>
                             </div>
                             <input type="text" class="hidden" name="chiefComplaintsJSON"/>
-                            <textarea class="fTextArea femr-textarea" id="chiefComplaint" name="chiefComplaint"></textarea>
+                            <textarea class="fTextArea femr-textarea" id="chiefComplaint" name="chiefComplaint" maxlength="2000"></textarea>
+                            <small id="chiefComplaintCharCount" class="femr-char-count">0 / 2000</small>
                             @if(viewModel.getSettings.isMultipleChiefComplaint) {
                                 <ol id="chiefComplaintList" class="femr-chief__list"></ol>
                             }

--- a/public/css/history.css
+++ b/public/css/history.css
@@ -400,6 +400,12 @@
     text-align: left;
 }
 
+.chiefComplaint {
+    white-space: normal;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
 .encbtns:hover {
     background: #f9fafb;
 }

--- a/public/css/manager/manager.css
+++ b/public/css/manager/manager.css
@@ -103,6 +103,12 @@
     color: var(--femr-color-text, #1c1917);
 }
 
+.manager-table__chief-complaint {
+    max-width: 240px;
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+
 .manager-table__link {
     color: var(--femr-color-primary, #2563eb);
     font-weight: 600;

--- a/public/css/triage_redesign.css
+++ b/public/css/triage_redesign.css
@@ -620,6 +620,18 @@
     gap: 8px;
 }
 
+.femr-char-count {
+    display: block;
+    text-align: right;
+    font-size: 0.75rem;
+    color: var(--femr-color-text-secondary, #6b7280);
+}
+
+.femr-char-count--limit {
+    color: var(--femr-color-primary, #dc2626);
+    font-weight: 600;
+}
+
 .femr-diabetes-prompt {
     padding: 24px;
     border-radius: 16px;

--- a/public/js/superuser/superuser.js
+++ b/public/js/superuser/superuser.js
@@ -6,6 +6,17 @@ $(document).ready(function(){
         $("[name='newTripCountry']").val($(this).find(':selected').attr('country-name'));
     });
 
+    var today = new Date().toISOString().split('T')[0];
+    $('#newTripStartDate').attr('min', today);
+
+    $('#newTripStartDate').change(function() {
+        var startDate = $(this).val();
+        $('#newTripEndDate').attr('min', startDate);
+        if ($('#newTripEndDate').val() && $('#newTripEndDate').val() < startDate) {
+            $('#newTripEndDate').val('');
+        }
+    });
+
     if ($.fn.DataTable) {
         if ($('#tripTable').length > 0)
             $('#tripTable').DataTable();

--- a/public/js/triage/triage.js
+++ b/public/js/triage/triage.js
@@ -966,5 +966,16 @@ $("#heightInches").change(function(){
     $(triageFields.patientVitals.heightInches).val(heightInches || "");
 });
 
+$('#chiefComplaint').on('input', function () {
+    var maxLen = parseInt($(this).attr('maxlength'), 10);
+    var currentLen = $(this).val().length;
+    var counter = $('#chiefComplaintCharCount');
+    counter.text(currentLen + ' / ' + maxLen);
+    if (currentLen >= maxLen) {
+        counter.addClass('femr-char-count--limit');
+    } else {
+        counter.removeClass('femr-char-count--limit');
+    }
+});
 
 

--- a/test/unit/app/femr/business/services/TranslationServiceTest.java
+++ b/test/unit/app/femr/business/services/TranslationServiceTest.java
@@ -3,6 +3,7 @@ package unit.app.femr.business.services;
 import controllers.AssetsFinder;
 import femr.business.services.core.*;
 import femr.ui.controllers.MedicalController;
+import femr.ui.controllers.helpers.FieldHelper;
 import femr.util.translation.TranslationServer;
 import org.junit.Assert;
 import org.junit.Before;
@@ -47,7 +48,8 @@ public class TranslationServiceTest {
                 photoService,
                 sessionService,
                 searchService,
-                vitalService);
+                vitalService,
+                new FieldHelper());
     }
 
     //MedicalController Tests


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to the handling of chief complaints, trip date validation, and UI enhancements for the FEMR application. The main changes include stricter validation for mission trip dates, better handling and display of chief complaints (including character limits and database storage), and UI/UX enhancements for both the triage and manager interfaces.

**Mission Trip Date Validation:**
* Enforced validation to ensure the trip start date is not in the past and the end date is not before the start date in `MissionTripService.java`.
* Added frontend validation to restrict selectable trip start/end dates using min attributes and dynamic updates in `superuser.js`.

**Chief Complaint Handling and UI:**
* Increased database storage for chief complaints by setting the `value` column to `TEXT` in `ChiefComplaint.java`.
* Added a 2000-character limit to the chief complaint textarea, with a live character counter in the triage view and supporting JS logic. [[1]](diffhunk://#diff-96ac8c516310254bfa9e649a549e62ddbaf4598956ab370a55989f0b4242e247L536-R537) [[2]](diffhunk://#diff-e2985f580341ae8eb8062185a54bb25b4b308d1b26f4ccfaf18e67d775776930R969-R979) [[3]](diffhunk://#diff-47906f30de13a7b686a4d843915d3374d6edae56155bf31cfcf7c80c6efc60bdR623-R634)
* Improved chief complaint display and wrapping in manager and history views, including new CSS classes for better readability. [[1]](diffhunk://#diff-41bd48858a87b36597e8aa1c1a11e7c73de5e26450a85c1de142a3161716188fL118-R118) [[2]](diffhunk://#diff-78445d5459cf0b19ced52f22679b4b52c3859536db058d14b62472d0e741e188R106-R111) [[3]](diffhunk://#diff-0720294f065b8a4fb7c191a475cbfc398cb1592e3452a3c5afacf875b108d8ceR403-R408)

**Dependency Injection and Test Updates:**
* Refactored `MedicalController` to inject `FieldHelper` instead of instantiating it directly, and updated tests accordingly. [[1]](diffhunk://#diff-5c7bea9e66dca72b4f9a74dded8a45380a35630dfcbdd9e750affe2bf06abb0dL64-R65) [[2]](diffhunk://#diff-5c7bea9e66dca72b4f9a74dded8a45380a35630dfcbdd9e750affe2bf06abb0dL75-R76) [[3]](diffhunk://#diff-8dde3773e1071fade17dfb2fd5d3de683dbc259c9bf6cbf6eb4801d63be18169R9-R15) [[4]](diffhunk://#diff-cc19d4bbc82604e04394fd90823220ae2b148640358367f0b85ae6dbf75d19f7R6) [[5]](diffhunk://#diff-cc19d4bbc82604e04394fd90823220ae2b148640358367f0b85ae6dbf75d19f7L50-R52)